### PR TITLE
Used newest Marshal version with JIT validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compares run time type validation of the following packages:
 
 * [class-validator](https://github.com/typestack/class-validator) + [class-transformer](https://github.com/typestack/class-transformer)
 * [io-ts](https://github.com/gcanti/io-ts)
-* [masrshal](https://github.com/marcj/marshal.ts)
+* [marshal](https://github.com/marcj/marshal.ts)
 * [runtypes](https://github.com/pelotom/runtypes)
 * [toi](https://github.com/hf/toi)
 * [ts-json-validator](https://github.com/ostrowr/ts-json-validator)

--- a/cases/marshal.ts
+++ b/cases/marshal.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import {
   f,
-  validatedPlainToClass,
+  validate,
   PropertyValidator,
   PropertyValidatorError,
 } from '@marcj/marshal';
@@ -72,6 +72,11 @@ export class MarshalCase extends Case implements Case {
   name = 'marshal';
 
   validate() {
-    return validatedPlainToClass(DataType, this.data);
+    const errors = validate(DataType, this.data);
+    if (errors.length === 0) {
+      return this.data;
+    }
+
+    throw new Error('Invalid');
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -831,9 +831,9 @@
       }
     },
     "@marcj/marshal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@marcj/marshal/-/marshal-2.0.0.tgz",
-      "integrity": "sha512-LAozgtkDCXXFUJvnQRRSszVYeYQdH4bVaYX4abIfB80/EoaPrBDK0K1Ivt3g2ax/+Y/oVSrsPZuBoR738sduZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@marcj/marshal/-/marshal-2.1.0.tgz",
+      "integrity": "sha512-pZ5SLw8lUFqd7BPxoIukTWrE/+nmiAYMLKqirvjySdmediVK/0MVKP9KosIxHdaN78hldMQETYRE8LMdPkJEYQ==",
       "requires": {
         "@marcj/estdlib": "^0.1.17",
         "buffer": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@marcj/marshal": "2.0.0",
+    "@marcj/marshal": "2.1.0",
     "@toi/toi": "1.2.0",
     "benny": "3.6.14",
     "class-transformer": "0.2.3",

--- a/test/__snapshots__/abstract.test.ts.snap
+++ b/test/__snapshots__/abstract.test.ts.snap
@@ -108,29 +108,9 @@ exports[`Case Class: io-ts should fail validation when number is not negative 1`
 
 exports[`Case Class: io-ts should fail validation when string is too short 1`] = `[Error: Invalid]`;
 
-exports[`Case Class: marshal should fail validation when number is not negative 1`] = `
-ValidationFailed {
-  "errors": Array [
-    ValidationError {
-      "code": "IsNegative",
-      "message": "Number must be negative.",
-      "path": "negNumber",
-    },
-  ],
-}
-`;
+exports[`Case Class: marshal should fail validation when number is not negative 1`] = `[Error: Invalid]`;
 
-exports[`Case Class: marshal should fail validation when string is too short 1`] = `
-ValidationFailed {
-  "errors": Array [
-    ValidationError {
-      "code": "MinLength",
-      "message": "String must have minimum length of 100.",
-      "path": "longString",
-    },
-  ],
-}
-`;
+exports[`Case Class: marshal should fail validation when string is too short 1`] = `[Error: Invalid]`;
 
 exports[`Case Class: runtypes should fail validation when number is not negative 1`] = `[ValidationError: Failed constraint check]`;
 


### PR DESCRIPTION
Also made sure it only validates using the `validate`
method. Although the new Marshal version is even with `validatedPlainToClass` the fastest by a huge margin, it wouldn't be fair to compare against other validators that do only validation and not class instance creation.