### PR TITLE
Suretype

### DIFF
--- a/cases/index.ts
+++ b/cases/index.ts
@@ -15,6 +15,7 @@ import { RulrCase } from './rulr';
 import { RuntypesCase } from './runtypes';
 import { SimpleRuntypesCase } from './simple-runtypes';
 import { SuperstructCase } from './superstruct';
+import { SuretypeCase } from './suretype';
 import { ToiCase } from './toi';
 import { TsJsonValidatorCase } from './ts-json-validator';
 import { TsUtilsCase } from './ts-utils';
@@ -39,6 +40,7 @@ export const cases = [
   RuntypesCase,
   SimpleRuntypesCase,
   SuperstructCase,
+  SuretypeCase,
   ToiCase,
   TsJsonValidatorCase,
   TsUtilsCase,

--- a/cases/suretype.ts
+++ b/cases/suretype.ts
@@ -17,14 +17,12 @@ const dataSchema = v.object({
     .required(),
 });
 
-const isData = compile(dataSchema, { simple: true });
+const ensureData = compile(dataSchema, { ensure: true });
 
 export class SuretypeCase extends Case implements Case {
   name = 'suretype';
 
   validate() {
-    if (isData(this.data)) {
-      return this.data;
-    }
+    return ensureData(this.data);
   }
 }

--- a/test/__snapshots__/abstract.test.ts.snap
+++ b/test/__snapshots__/abstract.test.ts.snap
@@ -810,6 +810,12 @@ exports[`Case Class: superstruct should fail validation when prop is missing 1`]
 
 exports[`Case Class: superstruct should fail validation when type is wrong 1`] = `[TypeError: Expected a value of type \`boolean\` but received \`"foo"\`.]`;
 
+exports[`Case Class: suretype should fail validation when deeply nested type is wrong 1`] = `[Error]`;
+
+exports[`Case Class: suretype should fail validation when prop is missing 1`] = `[Error]`;
+
+exports[`Case Class: suretype should fail validation when type is wrong 1`] = `[Error]`;
+
 exports[`Case Class: toi should fail validation when deeply nested type is wrong 1`] = `[Error: value does not match structure]`;
 
 exports[`Case Class: toi should fail validation when prop is missing 1`] = `[Error: value does not match structure]`;


### PR DESCRIPTION
Great work @moltar!

These aught to do it.

So, suretype has three validation _methods_, and looking at how the other tests work, it seems they _ensure_ the right type (or otherwise throw). This is corresponding to the `ensure` method in suretype. Let's hope this goes through your test pipeline!