### PR TITLE
Update to @badrap/valita v0.0.24 and rebuild snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,9 +518,9 @@
       }
     },
     "@badrap/valita": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.0.23.tgz",
-      "integrity": "sha512-+wSdaad8jUCjTdB1zboyLR/j+8oBkEY4qCUNMs5bggNFGcGdfJ3YvL3K/p2hQUw4S8A+jvjn37ntZKnGbbDTrA=="
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.0.24.tgz",
+      "integrity": "sha512-nEYJO2Sq/hnKyFXOOc4ze5fKo4pp3HACtxEAS2/ThJyFysyp0s/HStxoRY0qoo/wuU/k+dSwEgxJYioE16ZOjQ=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ailabs/ts-utils": "1.4.0",
-    "@badrap/valita": "0.0.23",
+    "@badrap/valita": "0.0.24",
     "@marcj/marshal": "2.1.13",
     "@mojotech/json-type-validation": "3.1.0",
     "@toi/toi": "1.3.0",

--- a/test/__snapshots__/abstract.test.ts.snap
+++ b/test/__snapshots__/abstract.test.ts.snap
@@ -957,7 +957,7 @@ DecodeError {
 
 exports[`Case Class: valita should fail validation when deeply nested type is wrong 1`] = `[ValitaError: invalid_type at .deeplyNested.bool (expected boolean)]`;
 
-exports[`Case Class: valita should fail validation when prop is missing 1`] = `[ValitaError: missing_key at . (missing key "boolean")]`;
+exports[`Case Class: valita should fail validation when prop is missing 1`] = `[ValitaError: missing_value at .boolean (missing value)]`;
 
 exports[`Case Class: valita should fail validation when type is wrong 1`] = `[ValitaError: invalid_type at .boolean (expected boolean)]`;
 


### PR DESCRIPTION
This pull request updates @badrap/valita to v0.0.24 and updates the related test snapshot.

Valita's v0.0.24 changed its error output format for missing object keys, so the snapshot checks in tests were failing.

