### PR TITLE
fix: missing benchmarks filter

### DIFF
--- a/docs/app.tsx
+++ b/docs/app.tsx
@@ -88,7 +88,7 @@ function normalizePartialValues(values: BenchmarkResult[]): BenchmarkResult[] {
     normalized.push(...results);
 
     const missingBenchmarks = BENCHMARKS.map(b => b.name).filter(
-      n => !results.find(r => r.name === n)
+      n => !results.find(r => r.benchmark === n)
     );
 
     missingBenchmarks.forEach(benchmark => {


### PR DESCRIPTION
While debugging I've randomly noticed that missingBenchmarks always contain all benchmarks even if they are not missing. Although they are filtered out later, I still decided to do this small fix.