### PR TITLE
Fix benchmarks with disabled cases

### DIFF
--- a/benchmarks/helpers/main.ts
+++ b/benchmarks/helpers/main.ts
@@ -31,6 +31,10 @@ export async function runAllBenchmarks() {
   const allResults: BenchmarkResult[] = [];
 
   for (const [benchmark, benchmarks] of getRegisteredBenchmarks()) {
+    if (benchmarks.length === 0) {
+      continue;
+    }
+
     const summary = await runBenchmarks(benchmark, benchmarks);
 
     summary.results.forEach(({ name, ops, margin }) => {

--- a/benchmarks/helpers/main.ts
+++ b/benchmarks/helpers/main.ts
@@ -1,5 +1,4 @@
 import { add, complete, cycle, suite } from 'benny';
-import { Summary } from 'benny/lib/internal/common-types';
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { writePreviewGraph } from './graph';
@@ -83,10 +82,7 @@ export async function createPreviewGraph() {
 }
 
 // run a benchmark fn with benny
-async function runBenchmarks(
-  name: string,
-  cases: BenchmarkCase[]
-): Promise<Summary | undefined> {
+async function runBenchmarks(name: string, cases: BenchmarkCase[]) {
   if (cases.length === 0) {
     return;
   }


### PR DESCRIPTION
Before if there were a disabled case it couldn't load it:
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/49292466/172892507-c77674ae-8d84-47dc-a880-2f1ca3542ab7.png">
After the fix `superstruct` benchmark and some other started working again:
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/49292466/172892906-86d278d2-32d0-4e8b-890c-2b5f53665a11.png">
