### PR TITLE
use node v18 for the preview image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
+        # benchmarked node versions must be kept in sync with:
+        #  - node-version matrix in pr.yml
+        #  - NODE_VERSIONS in app.tsx
+        #  - NODE_VERSION_FOR_PREVIEW in main.ts
         node-version:
           - 14.x
           - 16.x

--- a/benchmarks/helpers/main.ts
+++ b/benchmarks/helpers/main.ts
@@ -7,7 +7,7 @@ import { BenchmarkCase, BenchmarkResult } from './types';
 
 const DOCS_DIR = join(__dirname, '../../docs');
 const NODE_VERSION = process.env.NODE_VERSION || process.version;
-const NODE_VERSION_FOR_PREVIEW = 17;
+const NODE_VERSION_FOR_PREVIEW = 18;
 const TEST_PREVIEW_GENERATION = false;
 
 /**


### PR DESCRIPTION
A comment in release.yml now lists all node-version references that need to be synced.

I'm not using ENV vars because that would only help with the preview image generation. pr.yml and and app.tsx would need sth. more complicated and I think manually tracking them in a few files is still easier.