### PR TITLE
feat: improve benchmark preview svg

### DIFF
--- a/benchmarks/helpers/graph.ts
+++ b/benchmarks/helpers/graph.ts
@@ -78,13 +78,12 @@ function prepareData(values: BenchmarkResult[], resultCountToInclude = 4) {
     );
 
     // median of the rest as a comparison
-    const rest = sorted.slice(resultCountToInclude);
     const others: BenchmarkResult = {
       benchmark: v[0].benchmark,
       margin: 0,
-      name: '... rest',
+      name: '(median)',
       nodeVersion: v[0].nodeVersion,
-      ops: median(rest.map(x => x.ops)),
+      ops: median(sorted.map(x => x.ops)),
     };
 
     preparedResult.push(others);
@@ -108,7 +107,7 @@ async function previewGraph({ values }: PreviewGraphParams): Promise<string> {
     title: {
       anchor: 'middle',
       offset: 20,
-      text: 'Top 3 packages for each benchmark',
+      text: 'Top 3 packages for each benchmark + median, (ops count, better ⯈)',
       fontWeight: 'normal',
       fontSize: 16,
     },
@@ -124,7 +123,14 @@ async function previewGraph({ values }: PreviewGraphParams): Promise<string> {
           type: 'quantitative',
           sort: 'ascending',
         },
-        y: { field: 'name', type: 'nominal', title: null },
+        y: {
+          field: 'name',
+          type: 'nominal',
+          title: null,
+          // do not sort by name to keep the preparedValues sorting by ops
+          // instead
+          sort: null,
+        },
         color: {
           field: 'name',
           type: 'nominal',

--- a/benchmarks/helpers/main.ts
+++ b/benchmarks/helpers/main.ts
@@ -8,26 +8,11 @@ import { BenchmarkCase, BenchmarkResult } from './types';
 const DOCS_DIR = join(__dirname, '../../docs');
 const NODE_VERSION = process.env.NODE_VERSION || process.version;
 const NODE_VERSION_FOR_PREVIEW = 18;
-const TEST_PREVIEW_GENERATION = false;
 
 /**
  * Run all registered benchmarks and append the results to a file.
  */
 export async function runAllBenchmarks() {
-  if (TEST_PREVIEW_GENERATION) {
-    // during development: generate the preview using benchmark data from a previous run
-    const allResults: BenchmarkResult[] = JSON.parse(
-      readFileSync(join(DOCS_DIR, 'results', 'node-17.json')).toString()
-    ).results;
-
-    await writePreviewGraph({
-      filename: previewSvgFilename(),
-      values: allResults,
-    });
-
-    return;
-  }
-
   const allResults: BenchmarkResult[] = [];
 
   for (const [benchmark, benchmarks] of getRegisteredBenchmarks()) {


### PR DESCRIPTION
* sort by operations (fastest first)
* add more info to the title
* remove old dead test code

old: 
![image](https://user-images.githubusercontent.com/40309/202895131-7751bae6-8851-4ed3-9d55-8a7c73ec76a3.png)

new:
![image](https://user-images.githubusercontent.com/40309/202895153-d3557bb3-5f61-4963-a05e-6d811d41cfd6.png)

@mmamedel  noticed that in in this PR: https://github.com/moltar/typescript-runtime-type-benchmarks/pull/931