### PR TITLE
Add rescript-struct to the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * [purify-ts](https://github.com/gigobyte/purify)
 * [parse-dont-validate](https://github.com/Packer-Man/parse-dont-validate)
 * [r-assign](https://github.com/micnic/r-assign)
+* [rescript-struct](https://github.com/DZakh/rescript-struct)
 * [rulr](https://github.com/ryansmith94/rulr)
 * [runtypes](https://github.com/pelotom/runtypes)
 * [@sapphire/shapeshift](https://github.com/sapphiredev/shapeshift)

--- a/cases/index.ts
+++ b/cases/index.ts
@@ -14,6 +14,7 @@ export const cases = [
   'parse-dont-validate',
   'purify-ts',
   'r-assign',
+  'rescript-struct',
   'rulr',
   'runtypes',
   'sapphire-shapeshift',

--- a/cases/rescript-struct.ts
+++ b/cases/rescript-struct.ts
@@ -1,0 +1,87 @@
+import * as S from 'rescript-struct';
+
+import { createCase } from '../benchmarks';
+
+createCase('rescript-struct', 'parseSafe', () => {
+  const struct = S.object({
+    number: S.number(),
+    negNumber: S.number(),
+    maxNumber: S.number(),
+    string: S.string(),
+    longString: S.string(),
+    boolean: S.boolean(),
+    deeplyNested: S.object({
+      foo: S.string(),
+      num: S.number(),
+      bool: S.boolean(),
+    }),
+  });
+
+  return data => {
+    return struct.parseOrThrow(data);
+  };
+});
+
+createCase('rescript-struct', 'parseStrict', () => {
+  const struct = S.object({
+    number: S.number(),
+    negNumber: S.number(),
+    maxNumber: S.number(),
+    string: S.string(),
+    longString: S.string(),
+    boolean: S.boolean(),
+    deeplyNested: S.object({
+      foo: S.string(),
+      num: S.number(),
+      bool: S.boolean(),
+    }).strict(),
+  }).strict();
+
+  return data => {
+    return struct.parseOrThrow(data);
+  };
+});
+
+createCase('rescript-struct', 'assertLoose', () => {
+  const struct = S.object({
+    number: S.number(),
+    negNumber: S.number(),
+    maxNumber: S.number(),
+    string: S.string(),
+    longString: S.string(),
+    boolean: S.boolean(),
+    deeplyNested: S.object({
+      foo: S.string(),
+      num: S.number(),
+      bool: S.boolean(),
+    }),
+  });
+
+  return data => {
+    struct.parseOrThrow(data);
+
+    return true;
+  };
+});
+
+createCase('rescript-struct', 'assertStrict', () => {
+  const struct = S.object({
+    number: S.number(),
+    negNumber: S.number(),
+    maxNumber: S.number(),
+    string: S.string(),
+    longString: S.string(),
+    boolean: S.boolean(),
+    deeplyNested: S.object({
+      foo: S.string(),
+      num: S.number(),
+      bool: S.boolean(),
+    }).strict(),
+  }).strict();
+
+  return data => {
+    struct.parseOrThrow(data);
+
+    return true;
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "purify-ts": "1.3.0",
         "r-assign": "1.6.0",
         "reflect-metadata": "0.1.13",
+        "rescript": "10.1.0",
+        "rescript-struct": "3.0.0",
         "rulr": "8.7.6",
         "runtypes": "6.6.0",
         "serve": "12.0.1",
@@ -8088,6 +8090,26 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "node_modules/rescript": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.0.tgz",
+      "integrity": "sha512-85KLtBECo+hYwObbifXk5xpxUCUFMWgCR1w7hDDGhhXIXqEpHQ2ds6o++YPxzXjLuU1/qA7Iovq2zUX4opejQw==",
+      "hasInstallScript": true,
+      "bin": {
+        "bsc": "bsc",
+        "bsrefmt": "bsrefmt",
+        "bstracing": "lib/bstracing",
+        "rescript": "rescript"
+      }
+    },
+    "node_modules/rescript-struct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rescript-struct/-/rescript-struct-3.0.0.tgz",
+      "integrity": "sha512-1KxPK+g2p0eBxUWvCcYjGANe4CbRvv+HHN64wvBONxBngtmyuu4KkPjRlWNPCDATvW8U7WlKup2kmLKkAoL+Tg==",
+      "peerDependencies": {
+        "rescript": "10.1.x"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -16108,6 +16130,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "rescript": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.0.tgz",
+      "integrity": "sha512-85KLtBECo+hYwObbifXk5xpxUCUFMWgCR1w7hDDGhhXIXqEpHQ2ds6o++YPxzXjLuU1/qA7Iovq2zUX4opejQw=="
+    },
+    "rescript-struct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rescript-struct/-/rescript-struct-3.0.0.tgz",
+      "integrity": "sha512-1KxPK+g2p0eBxUWvCcYjGANe4CbRvv+HHN64wvBONxBngtmyuu4KkPjRlWNPCDATvW8U7WlKup2kmLKkAoL+Tg==",
+      "requires": {}
     },
     "resolve": {
       "version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "purify-ts": "1.3.0",
     "r-assign": "1.6.0",
     "reflect-metadata": "0.1.13",
+    "rescript": "10.1.0",
+    "rescript-struct": "3.0.0",
     "rulr": "8.7.6",
     "runtypes": "6.6.0",
     "serve": "12.0.1",

--- a/test/benchmarks.test.ts
+++ b/test/benchmarks.test.ts
@@ -18,6 +18,7 @@ import '../cases/ok-computer';
 import '../cases/parse-dont-validate';
 import '../cases/purify-ts';
 import '../cases/r-assign';
+import '../cases/rescript-struct';
 import '../cases/rulr';
 import '../cases/runtypes';
 import '../cases/sapphire-shapeshift';


### PR DESCRIPTION
Want to add my parsing library. Should be a new winner 😊

Also, I maintain a fork of the repo that contains some other parsing libraries for ReScript (without TS support). It's pretty tedious to do, so I thought maybe it's possible to move them to your repo and hide them behind a separate tab? What do you think? https://github.com/DZakh/rescript-runtime-type-benchmarks