### PR TITLE
chore(deps) typebox 0.24.41 > 0.25.21 | ts semantics

### DIFF
--- a/cases/sinclair-typebox.ts
+++ b/cases/sinclair-typebox.ts
@@ -1,6 +1,11 @@
 import { Type } from '@sinclair/typebox';
 import { TypeCompiler } from '@sinclair/typebox/compiler';
+import { TypeSystem } from '@sinclair/typebox/system';
 import { createCase } from '../benchmarks';
+
+// Use TypeScript Checking Semantics
+TypeSystem.AllowArrayObjects = true;
+TypeSystem.AllowNaN = true;
 
 createCase('@sinclair/typebox', 'assertLoose', () => {
   const dataType = Type.Object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@marcj/marshal": "2.1.13",
         "@mojotech/json-type-validation": "3.1.0",
         "@sapphire/shapeshift": "3.6.0",
-        "@sinclair/typebox": "0.24.41",
+        "@sinclair/typebox": "^0.25.21",
         "@skarab/tson": "1.5.1",
         "@toi/toi": "1.3.0",
         "@typeofweb/schema": "0.7.3",
@@ -2357,6 +2357,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
+    },
     "node_modules/@jest/source-map": {
       "version": "29.0.0",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
@@ -2615,9 +2621,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
-      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA=="
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -11834,6 +11840,14 @@
       "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.24.1"
+      },
+      "dependencies": {
+        "@sinclair/typebox": {
+          "version": "0.24.51",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+          "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+          "dev": true
+        }
       }
     },
     "@jest/source-map": {
@@ -12050,9 +12064,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
-      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA=="
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@marcj/marshal": "2.1.13",
     "@mojotech/json-type-validation": "3.1.0",
     "@sapphire/shapeshift": "3.6.0",
-    "@sinclair/typebox": "0.24.41",
+    "@sinclair/typebox": "^0.25.21",
     "@skarab/tson": "1.5.1",
     "@toi/toi": "1.3.0",
     "@typeofweb/schema": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@marcj/marshal": "2.1.13",
     "@mojotech/json-type-validation": "3.1.0",
     "@sapphire/shapeshift": "3.6.0",
-    "@sinclair/typebox": "^0.25.21",
+    "@sinclair/typebox": "0.25.21",
     "@skarab/tson": "1.5.1",
     "@toi/toi": "1.3.0",
     "@typeofweb/schema": "0.7.3",


### PR DESCRIPTION
@moltar @hoeck Hi!

This PR updates TypeBox from version 0.24.41 to 0.25.21 (minor semver) which includes a number of optimizations  implemented since the 0.24.x release. In addition this PR applies a configuration update to align TypeBox type checking behaviors inline with TypeScript semantics for the following permissible cases. 

[TypeScript Link Here](https://www.typescriptlang.org/play?#code/PTAEEEBtIewd3AJ0QQwJ4HkBGArApgMYAuAzgLABQAZgK4B2xAljHaEXiUQIwAUAbikg08ALlAxchIgEpQAbwC+ldp14BtLgBpQAJm0BmbQBYAurJDiA1mKJoADnhhVQG7XtCHQp0AF4-oAHIJfGIAykoLKFg4ADkUGMpaBiJmVhUiHX5BYTE6GgBbLDxEWUVlDgyeOJjzMBhrNntHZ2rffwC8wuKAoA)

```typescript
// AllowArrayObjects
function test1(value: object) {}
test1([1, 2, 3, 4]) // ok: typeof [1, 2, 3, 4] === 'object'

// AllowNaN
function test2(value: number) {}
test2(NaN) // ok: typeof NaN === 'number'
```
Note: These configurations ease JSON Schema checks for `number` and `object` types only and align TypeBox validation rules inline with the current AOT (compiled) solutions which opt for TypeScript semantics. This configuration is to help highlight disparities between JIT (eval) and AOT (compiled) validation performance for equivalent check logic; and to get a lens on performance degradation for JIT solutions (TypeBox, Ajv) across varying Node versions.

Additional JIT | AOT Research / Performance Benchmarking can be found at the following links if interested.

Project: https://github.com/sinclairzx81/runtime-type-benchmarks
Results: https://sinclairzx81.github.io/runtime-type-benchmarks/

Submitting for review