### PR TITLE
Add `caketype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 * [ajv](https://ajv.js.org/)
 * [bueno](https://github.com/philipnilsson/bueno)
+* [caketype](https://github.com/justinyaodu/caketype)
 * [class-validator](https://github.com/typestack/class-validator) + [class-transformer](https://github.com/typestack/class-transformer)
 * [computed-types](https://github.com/neuledge/computed-types)
 * [decoders](https://github.com/nvie/decoders)

--- a/cases/caketype.ts
+++ b/cases/caketype.ts
@@ -1,7 +1,11 @@
 import { bake, boolean, number, string } from 'caketype';
 import { createCase } from '../benchmarks';
 
-const cake = bake({
+// caketype requires TS 4.7 for type inference, but using `any` below allows
+// this code to type-check in older versions. It should be safe to remove in
+// TS 4.7+.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const cake: any = bake({
   number: number,
   negNumber: number,
   maxNumber: number,

--- a/cases/caketype.ts
+++ b/cases/caketype.ts
@@ -1,0 +1,39 @@
+import { bake, boolean, number, string } from 'caketype';
+import { createCase } from '../benchmarks';
+
+const cake = bake({
+  number: number,
+  negNumber: number,
+  maxNumber: number,
+  string: string,
+  longString: string,
+  boolean: boolean,
+  deeplyNested: {
+    foo: string,
+    num: number,
+    bool: boolean,
+  },
+});
+
+// Safe parsing is not supported because extra keys are not removed from the input.
+
+createCase('caketype', 'parseStrict', () => data => {
+  if (cake.is(data)) {
+    return data;
+  }
+  throw new Error();
+});
+
+createCase('caketype', 'assertLoose', () => data => {
+  if (cake.isShape(data)) {
+    return true;
+  }
+  throw new Error();
+});
+
+createCase('caketype', 'assertStrict', () => data => {
+  if (cake.is(data)) {
+    return true;
+  }
+  throw new Error();
+});

--- a/cases/index.ts
+++ b/cases/index.ts
@@ -1,6 +1,7 @@
 export const cases = [
   'ajv',
   'bueno',
+  'caketype',
   'class-validator',
   'computed-types',
   'decoders',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@marcj/marshal": "2.1.13",
         "@mojotech/json-type-validation": "3.1.0",
         "@sapphire/shapeshift": "3.6.0",
-        "@sinclair/typebox": "^0.25.21",
+        "@sinclair/typebox": "0.25.21",
         "@skarab/tson": "1.5.1",
         "@toi/toi": "1.3.0",
         "@typeofweb/schema": "0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ajv": "8.11.0",
         "benny": "3.7.1",
         "bueno": "0.1.5",
+        "caketype": "^0.5.0",
         "class-transformer": "0.5.1",
         "class-transformer-validator": "0.9.1",
         "class-validator": "0.14.0",
@@ -3759,6 +3760,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/caketype": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/caketype/-/caketype-0.5.0.tgz",
+      "integrity": "sha512-RXb+W/PttNXH3TdYLIrNwvRnyPignAwjwIoLbE19ZmyQaDN7lMbaZMlchUtkr6sjDbpy+Tl0lsTcAjYwtZA3Vw=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -12909,6 +12915,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "caketype": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/caketype/-/caketype-0.5.0.tgz",
+      "integrity": "sha512-RXb+W/PttNXH3TdYLIrNwvRnyPignAwjwIoLbE19ZmyQaDN7lMbaZMlchUtkr6sjDbpy+Tl0lsTcAjYwtZA3Vw=="
     },
     "call-bind": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ajv": "8.11.0",
         "benny": "3.7.1",
         "bueno": "0.1.5",
-        "caketype": "^0.5.0",
+        "caketype": "0.5.0",
         "class-transformer": "0.5.1",
         "class-transformer-validator": "0.9.1",
         "class-validator": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ajv": "8.11.0",
     "benny": "3.7.1",
     "bueno": "0.1.5",
+    "caketype": "^0.5.0",
     "class-transformer": "0.5.1",
     "class-transformer-validator": "0.9.1",
     "class-validator": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ajv": "8.11.0",
     "benny": "3.7.1",
     "bueno": "0.1.5",
-    "caketype": "^0.5.0",
+    "caketype": "0.5.0",
     "class-transformer": "0.5.1",
     "class-transformer-validator": "0.9.1",
     "class-validator": "0.14.0",

--- a/test/benchmarks.test.ts
+++ b/test/benchmarks.test.ts
@@ -5,6 +5,7 @@ import { cases } from '../cases';
 // imported `test` and `describe`
 import '../cases/ajv';
 import '../cases/bueno';
+import '../cases/caketype';
 import '../cases/class-validator';
 import '../cases/computed-types';
 import '../cases/decoders';


### PR DESCRIPTION
I used [this commit](https://github.com/moltar/typescript-runtime-type-benchmarks/commit/38cdb380df72ed7452fb26d117fcc6202e40a1f1) as a template, and tested it locally with `npm run start run zod caketype`.

`caketype` requires TypeScript 4.7, but the tests seem to run with TypeScript 4.6, which was causing type errors. However, setting the type of the schema object to `any` suppresses these. I hope that's okay for the purposes of runtime benchmarking :sweat_smile:

Closes #1028.