### PR TITLE
fix: preview svg in vega lite v5

### DIFF
--- a/benchmarks/helpers/graph.ts
+++ b/benchmarks/helpers/graph.ts
@@ -20,7 +20,7 @@ function assertNever(x: never): never {
   throw new Error(`assert-never: unknown value: ${x}`);
 }
 
-function getBenchmarkLabel(benchmark: AvailableBenchmarksIds): string {
+function getBenchmarkLabel(benchmark: AvailableBenchmarksIds) {
   switch (benchmark) {
     case 'assertLoose':
       return 'Loose Assertion';
@@ -35,6 +35,8 @@ function getBenchmarkLabel(benchmark: AvailableBenchmarksIds): string {
   }
 }
 
+type BenchmarkLabel = ReturnType<typeof getBenchmarkLabel>;
+
 function median(values: number[]) {
   if (!values.length) {
     return NaN;
@@ -47,6 +49,9 @@ function median(values: number[]) {
   return (values[values.length / 2 - 1] + values[values.length / 2]) / 2;
 }
 
+// Cheap aggregation of benchmark data.
+// For the repeated bar chart, vega-lite expects a numeric value for each
+// repeated field (the benchmark label) for each benchmarked library (`name`).
 function prepareData(values: BenchmarkResult[], resultCountToInclude = 4) {
   const bins = new Map<string, BenchmarkResult[]>();
 
@@ -61,7 +66,21 @@ function prepareData(values: BenchmarkResult[], resultCountToInclude = 4) {
     bin.push(result);
   });
 
-  const preparedResult: BenchmarkResult[] = [];
+  const preparedResult: any[] = [];
+
+  function updateResult(
+    name: string,
+    benchmarkLabel: BenchmarkLabel,
+    ops: number
+  ) {
+    const existing = preparedResult.find(v => v.name === name);
+
+    if (existing) {
+      existing[benchmarkLabel] = ops;
+    } else {
+      preparedResult.push({ name, [benchmarkLabel]: ops });
+    }
+  }
 
   bins.forEach(v => {
     if (!v.length) {
@@ -71,30 +90,31 @@ function prepareData(values: BenchmarkResult[], resultCountToInclude = 4) {
     const sorted = v.sort((a, b) => b.ops - a.ops);
 
     // the N fasted benchmarks
-    preparedResult.push(
-      ...sorted
-        .slice(0, resultCountToInclude)
-        .map(r => ({ ...r, color: 'fast' }))
-    );
+    sorted
+      .slice(0, resultCountToInclude)
+      .forEach(r =>
+        updateResult(
+          r.name,
+          getBenchmarkLabel(r.benchmark as AvailableBenchmarksIds),
+          r.ops
+        )
+      );
+  });
+
+  // add median last to make it appear at the bottom of each individual
+  // barchart
+  bins.forEach(v => {
+    const sorted = v.sort((a, b) => b.ops - a.ops);
 
     // median of the rest as a comparison
-    const others: BenchmarkResult = {
-      benchmark: v[0].benchmark,
-      margin: 0,
-      name: '(median)',
-      nodeVersion: v[0].nodeVersion,
-      ops: median(sorted.map(x => x.ops)),
-    };
-
-    preparedResult.push(others);
+    updateResult(
+      '(median)',
+      getBenchmarkLabel(v[0].benchmark as AvailableBenchmarksIds),
+      median(sorted.map(x => x.ops))
+    );
   });
 
-  return preparedResult.map(v => {
-    return {
-      ...v,
-      [getBenchmarkLabel(v.benchmark as AvailableBenchmarksIds)]: v.ops,
-    };
-  });
+  return preparedResult;
 }
 
 // generate a nice preview graph
@@ -129,6 +149,9 @@ async function previewGraph({ values }: PreviewGraphParams): Promise<string> {
           title: null,
           // do not sort by name to keep the preparedValues sorting by ops
           // instead
+          // also, we cannot use `sort: '-x'` because that will include every
+          // top 3 library in every repeated bar chart, regardless whether it
+          // is in the top 3 of the current benchmark
           sort: null,
         },
         color: {

--- a/docs/results/preview.svg
+++ b/docs/results/preview.svg
@@ -7,72 +7,81 @@
             <g class="mark-group role-axis" aria-hidden="true">
                 <path class="background" aria-hidden="true" d="M189.5 102.5Z" pointer-events="none"/>
                 <g class="mark-rule role-axis-grid" pointer-events="none" stroke="#ddd">
-                    <path d="M189.5 102.5v-60M239.5 102.5v-60M289.5 102.5v-60M339.5 102.5v-60M389.5 102.5v-60"/>
+                    <path d="M189.5 102.5v-60M233.5 102.5v-60M278.5 102.5v-60M322.5 102.5v-60M367.5 102.5v-60"/>
                 </g>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Safe Parsing' for a linear scale with values from 0 to 40,000,000">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Safe Parsing' for a linear scale with values from 0 to 45,000,000">
                 <path class="background" aria-hidden="true" d="M189.5 102.5Z"/>
                 <g class="mark-rule role-axis-tick" stroke="#888">
-                    <path d="M189.5 102.5v5M239.5 102.5v5M289.5 102.5v5M339.5 102.5v5M389.5 102.5v5"/>
+                    <path d="M189.5 102.5v5M233.5 102.5v5M278.5 102.5v5M322.5 102.5v5M367.5 102.5v5"/>
                 </g>
                 <g class="mark-text role-axis-label" font-family="sans-serif" font-size="10" fill="#000">
                     <text transform="translate(189.5 117.5)">0</text>
-                    <text text-anchor="end" transform="translate(389.5 117.5)">40,000,000</text>
+                    <text text-anchor="middle" transform="translate(278.389 117.5)">20,000,000</text>
+                    <text text-anchor="middle" transform="translate(367.278 117.5)">40,000,000</text>
                 </g>
                 <path stroke="#888" d="M189.5 102.5h200" class="mark-rule role-axis-domain"/>
                 <text text-anchor="middle" transform="translate(289.5 132.5)" font-family="sans-serif" font-size="11" font-weight="bold" fill="#000" class="mark-text role-axis-title">Safe Parsing</text>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: rescript-struct, typia, spectypes, (median)">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: typia, spectypes, rescript-struct, (median)">
                 <path class="background" aria-hidden="true" d="M189.5 42.5Z"/>
                 <g class="mark-rule role-axis-tick" stroke="#888">
                     <path d="M189.5 49.5h-5M189.5 64.5h-5M189.5 79.5h-5M189.5 94.5h-5"/>
                 </g>
                 <g class="mark-text role-axis-label" text-anchor="end" font-family="sans-serif" font-size="10" fill="#000">
-                    <text transform="translate(182.5 52.5)">rescript-struct</text>
-                    <text transform="translate(182.5 67.5)">typia</text>
-                    <text transform="translate(182.5 82.5)">spectypes</text>
+                    <text transform="translate(182.5 52.5)">typia</text>
+                    <text transform="translate(182.5 67.5)">spectypes</text>
+                    <text transform="translate(182.5 82.5)">rescript-struct</text>
                     <text transform="translate(182.5 97.5)">(median)</text>
                 </g>
                 <path stroke="#888" d="M189.5 42.5v60" class="mark-rule role-axis-domain"/>
             </g>
             <g class="mark-rect role-mark child__Safe_Parsing_marks" aria-roledescription="rect mark container">
-                <path aria-label="Safe Parsing: 38229355; name: rescript-struct" aria-roledescription="bar" d="M189 42.75h191.147v13.5H189Z" fill="#e45756"/>
-                <path aria-label="Safe Parsing: 20917519; name: typia" aria-roledescription="bar" d="M189 57.75v13.5Z" fill="#eeca3b"/>
-                <path aria-label="Safe Parsing: 13174308; name: spectypes" aria-roledescription="bar" d="M189 72.75v13.5Z" fill="#72b7b2"/>
-                <path aria-label="Safe Parsing: 699680; name: (median)" aria-roledescription="bar" d="M189 87.75v13.5Z" fill="#4c78a8"/>
+                <path aria-label="Safe Parsing: 28522637; name: typia" aria-roledescription="bar" d="M189 42.75h126.767v13.5H189Z" fill="#eeca3b"/>
+                <path aria-label="Safe Parsing: 18951268; name: spectypes" aria-roledescription="bar" d="M189 57.75h84.228v13.5H189Z" fill="#72b7b2"/>
+                <path aria-label="Safe Parsing: 43968374; name: rescript-struct" aria-roledescription="bar" d="M189 72.75h195.415v13.5H189Z" fill="#e45756"/>
+                <path aria-label="Safe Parsing: 795225; name: (median)" aria-roledescription="bar" d="M189 87.75h3.534v13.5H189Z" fill="#4c78a8"/>
             </g>
         </g>
         <g class="mark-group role-scope child__Strict_Parsing_group" aria-roledescription="group mark container">
             <path class="background" aria-hidden="true" d="M576.5 42.5h200v60h-200Z" stroke="#ddd"/>
             <g class="mark-group role-axis" aria-hidden="true">
                 <path class="background" aria-hidden="true" d="M576.5 102.5Z" pointer-events="none"/>
-                <path stroke="#ddd" d="M676.5 102.5v-60" class="mark-rule role-axis-grid" pointer-events="none"/>
+                <g class="mark-rule role-axis-grid" pointer-events="none" stroke="#ddd">
+                    <path d="M576.5 102.5v-60M621.5 102.5v-60M667.5 102.5v-60M712.5 102.5v-60M758.5 102.5v-60"/>
+                </g>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Strict Parsing' for a linear scale with values from 0 to 0">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Strict Parsing' for a linear scale with values from 0 to 22,000,000">
                 <path class="background" aria-hidden="true" d="M576.5 102.5Z"/>
-                <path stroke="#888" d="M676.5 102.5v5" class="mark-rule role-axis-tick"/>
-                <text text-anchor="middle" transform="translate(676.5 117.5)" font-family="sans-serif" font-size="10" fill="#000" class="mark-text role-axis-label">0</text>
+                <g class="mark-rule role-axis-tick" stroke="#888">
+                    <path d="M576.5 102.5v5M621.5 102.5v5M667.5 102.5v5M712.5 102.5v5M758.5 102.5v5"/>
+                </g>
+                <g class="mark-text role-axis-label" font-family="sans-serif" font-size="10" fill="#000">
+                    <text transform="translate(576.5 117.5)">0</text>
+                    <text text-anchor="middle" transform="translate(667.41 117.5)">10,000,000</text>
+                    <text text-anchor="middle" transform="translate(758.318 117.5)">20,000,000</text>
+                </g>
                 <path stroke="#888" d="M576.5 102.5h200" class="mark-rule role-axis-domain"/>
                 <text text-anchor="middle" transform="translate(676.5 132.5)" font-family="sans-serif" font-size="11" font-weight="bold" fill="#000" class="mark-text role-axis-title">Strict Parsing</text>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: typia, ts-runtime-checks, spectypes, (median)">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: ts-runtime-checks, typia, spectypes, (median)">
                 <path class="background" aria-hidden="true" d="M576.5 42.5Z"/>
                 <g class="mark-rule role-axis-tick" stroke="#888">
                     <path d="M576.5 49.5h-5M576.5 64.5h-5M576.5 79.5h-5M576.5 94.5h-5"/>
                 </g>
                 <g class="mark-text role-axis-label" text-anchor="end" font-family="sans-serif" font-size="10" fill="#000">
-                    <text transform="translate(569.5 52.5)">typia</text>
-                    <text transform="translate(569.5 67.5)">ts-runtime-checks</text>
+                    <text transform="translate(569.5 52.5)">ts-runtime-checks</text>
+                    <text transform="translate(569.5 67.5)">typia</text>
                     <text transform="translate(569.5 82.5)">spectypes</text>
                     <text transform="translate(569.5 97.5)">(median)</text>
                 </g>
                 <path stroke="#888" d="M576.5 42.5v60" class="mark-rule role-axis-domain"/>
             </g>
             <g class="mark-rect role-mark child__Strict_Parsing_marks" aria-roledescription="rect mark container">
-                <path aria-label="Strict Parsing: 21293601; name: typia" aria-roledescription="bar" d="M576 42.75v13.5Z" fill="#eeca3b"/>
-                <path aria-label="Strict Parsing: 19584636; name: ts-runtime-checks" aria-roledescription="bar" d="M576 57.75v13.5Z" fill="#54a24b"/>
-                <path aria-label="Strict Parsing: 16007084; name: spectypes" aria-roledescription="bar" d="M576 72.75v13.5Z" fill="#72b7b2"/>
-                <path aria-label="Strict Parsing: 759801; name: (median)" aria-roledescription="bar" d="M576 87.75v13.5Z" fill="#4c78a8"/>
+                <path aria-label="Strict Parsing: 20385712; name: ts-runtime-checks" aria-roledescription="bar" d="M576 42.75h185.325v13.5H576Z" fill="#54a24b"/>
+                <path aria-label="Strict Parsing: 20109238; name: typia" aria-roledescription="bar" d="M576 57.75h182.811v13.5H576Z" fill="#eeca3b"/>
+                <path aria-label="Strict Parsing: 19576956; name: spectypes" aria-roledescription="bar" d="M576 72.75h177.972v13.5H576Z" fill="#72b7b2"/>
+                <path aria-label="Strict Parsing: 788393; name: (median)" aria-roledescription="bar" d="M576 87.75h7.167v13.5H576Z" fill="#4c78a8"/>
             </g>
         </g>
         <g class="mark-group role-scope child__Loose_Assertion_group" aria-roledescription="group mark container">
@@ -109,10 +118,10 @@
                 <path stroke="#888" d="M189.5 156.5v60" class="mark-rule role-axis-domain"/>
             </g>
             <g class="mark-rect role-mark child__Loose_Assertion_marks" aria-roledescription="rect mark container">
-                <path aria-label="Loose Assertion: 110981782; name: ts-runtime-checks" aria-roledescription="bar" d="M189 156.75h184.97v13.5H189Z" fill="#54a24b"/>
-                <path aria-label="Loose Assertion: 99270630; name: typia" aria-roledescription="bar" d="M189 171.75h165.451v13.5H189Z" fill="#eeca3b"/>
-                <path aria-label="Loose Assertion: 83014678; name: spectypes" aria-roledescription="bar" d="M189 186.75h138.358v13.5H189Z" fill="#72b7b2"/>
-                <path aria-label="Loose Assertion: 782702; name: (median)" aria-roledescription="bar" d="M189 201.75h1.305v13.5H189Z" fill="#4c78a8"/>
+                <path aria-label="Loose Assertion: 116984577; name: ts-runtime-checks" aria-roledescription="bar" d="M189 156.75h194.974v13.5H189Z" fill="#54a24b"/>
+                <path aria-label="Loose Assertion: 98344395; name: typia" aria-roledescription="bar" d="M189 171.75h163.907v13.5H189Z" fill="#eeca3b"/>
+                <path aria-label="Loose Assertion: 88618040; name: spectypes" aria-roledescription="bar" d="M189 186.75h147.697v13.5H189Z" fill="#72b7b2"/>
+                <path aria-label="Loose Assertion: 1065846; name: (median)" aria-roledescription="bar" d="M189 201.75h1.776v13.5H189Z" fill="#4c78a8"/>
             </g>
         </g>
         <g class="mark-group role-scope child__Strict_Assertion_group" aria-roledescription="group mark container">
@@ -120,40 +129,40 @@
             <g class="mark-group role-axis" aria-hidden="true">
                 <path class="background" aria-hidden="true" d="M576.5 216.5Z" pointer-events="none"/>
                 <g class="mark-rule role-axis-grid" pointer-events="none" stroke="#ddd">
-                    <path d="M576.5 216.5v-60M621.5 216.5v-60M667.5 216.5v-60M712.5 216.5v-60M758.5 216.5v-60"/>
+                    <path d="M576.5 216.5v-60M618.5 216.5v-60M659.5 216.5v-60M701.5 216.5v-60M743.5 216.5v-60"/>
                 </g>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Strict Assertion' for a linear scale with values from 0 to 22,000,000">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="X-axis titled 'Strict Assertion' for a linear scale with values from 0 to 24,000,000">
                 <path class="background" aria-hidden="true" d="M576.5 216.5Z"/>
                 <g class="mark-rule role-axis-tick" stroke="#888">
-                    <path d="M576.5 216.5v5M621.5 216.5v5M667.5 216.5v5M712.5 216.5v5M758.5 216.5v5"/>
+                    <path d="M576.5 216.5v5M618.5 216.5v5M659.5 216.5v5M701.5 216.5v5M743.5 216.5v5"/>
                 </g>
                 <g class="mark-text role-axis-label" font-family="sans-serif" font-size="10" fill="#000">
                     <text transform="translate(576.5 231.5)">0</text>
-                    <text text-anchor="middle" transform="translate(667.41 231.5)">10,000,000</text>
-                    <text text-anchor="middle" transform="translate(758.318 231.5)">20,000,000</text>
+                    <text text-anchor="middle" transform="translate(659.833 231.5)">10,000,000</text>
+                    <text text-anchor="middle" transform="translate(743.167 231.5)">20,000,000</text>
                 </g>
                 <path stroke="#888" d="M576.5 216.5h200" class="mark-rule role-axis-domain"/>
                 <text text-anchor="middle" transform="translate(676.5 246.5)" font-family="sans-serif" font-size="11" font-weight="bold" fill="#000" class="mark-text role-axis-title">Strict Assertion</text>
             </g>
-            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: typia, ts-runtime-checks, @sinclair/typebox, (median)">
+            <g pointer-events="none" class="mark-group role-axis" aria-roledescription="axis" aria-label="Y-axis for a discrete scale with 4 values: ts-runtime-checks, typia, @sinclair/typebox, (median)">
                 <path class="background" aria-hidden="true" d="M576.5 156.5Z"/>
                 <g class="mark-rule role-axis-tick" stroke="#888">
                     <path d="M576.5 163.5h-5M576.5 178.5h-5M576.5 193.5h-5M576.5 208.5h-5"/>
                 </g>
                 <g class="mark-text role-axis-label" text-anchor="end" font-family="sans-serif" font-size="10" fill="#000">
-                    <text transform="translate(569.5 166.5)">typia</text>
-                    <text transform="translate(569.5 181.5)">ts-runtime-checks</text>
+                    <text transform="translate(569.5 166.5)">ts-runtime-checks</text>
+                    <text transform="translate(569.5 181.5)">typia</text>
                     <text transform="translate(569.5 196.5)">@sinclair/typebox</text>
                     <text transform="translate(569.5 211.5)">(median)</text>
                 </g>
                 <path stroke="#888" d="M576.5 156.5v60" class="mark-rule role-axis-domain"/>
             </g>
             <g class="mark-rect role-mark child__Strict_Assertion_marks" aria-roledescription="rect mark container">
-                <path aria-label="Strict Assertion: 20803862; name: typia" aria-roledescription="bar" d="M576 156.75v13.5Z" fill="#eeca3b"/>
-                <path aria-label="Strict Assertion: 20235437; name: ts-runtime-checks" aria-roledescription="bar" d="M576 171.75v13.5Z" fill="#54a24b"/>
-                <path aria-label="Strict Assertion: 20112772; name: @sinclair/typebox" aria-roledescription="bar" d="M576 186.75h182.843v13.5H576Z" fill="#f58518"/>
-                <path aria-label="Strict Assertion: 612896.5; name: (median)" aria-roledescription="bar" d="M576 201.75v13.5Z" fill="#4c78a8"/>
+                <path aria-label="Strict Assertion: 21649594; name: ts-runtime-checks" aria-roledescription="bar" d="M576 156.75h180.413v13.5H576Z" fill="#54a24b"/>
+                <path aria-label="Strict Assertion: 19328724; name: typia" aria-roledescription="bar" d="M576 171.75h161.073v13.5H576Z" fill="#eeca3b"/>
+                <path aria-label="Strict Assertion: 22867123; name: @sinclair/typebox" aria-roledescription="bar" d="M576 186.75h190.56v13.5H576Z" fill="#f58518"/>
+                <path aria-label="Strict Assertion: 660119.5; name: (median)" aria-roledescription="bar" d="M576 201.75h5.501v13.5H576Z" fill="#4c78a8"/>
             </g>
         </g>
         <g class="mark-group role-title">


### PR DESCRIPTION
fixes #1082

Sorting each individual preview bar chart by number of ops is not possible with this approach any more. That did only work due to hidden implementation behavior of vega-lite version 4.