### PR TITLE
build: upgrades `ts-runtime-checks` and `typescript` versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@badrap/valita": "0.2.1",
         "@mojotech/json-type-validation": "3.1.0",
         "@sapphire/shapeshift": "3.9.2",
-        "@sinclair/typebox": "0.28.18",
+        "@sinclair/typebox": "0.29.4",
         "@skarab/tson": "1.5.1",
         "@toi/toi": "1.3.0",
         "@typeofweb/schema": "0.7.3",
@@ -54,10 +54,9 @@
         "ts-interface-checker": "1.0.2",
         "ts-json-validator": "0.7.1",
         "ts-node": "10.9.1",
-        "ts-runtime-checks": "0.1.3",
-        "ttypescript": "1.5.15",
-        "typescript": "4.9.5",
-        "typia": "4.1.1",
+        "ts-runtime-checks": "0.2.0",
+        "typescript": "5.1.6",
+        "typia": "4.1.6",
         "vality": "6.3.3",
         "vega": "5.25.0",
         "vega-lite": "5.11.0",
@@ -80,6 +79,7 @@
         "jest": "29.5.0",
         "rimraf": "5.0.1",
         "ts-jest": "29.1.0",
+        "ts-patch": "^3.0.1",
         "tsconfigs": "4.0.2"
       }
     },
@@ -2848,9 +2848,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.28.18",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.28.18.tgz",
-      "integrity": "sha512-I19d36CXlLAsm+nrl7VKsYyirFLtdebT2nlfV3Knvo0tnk8B8UKyt3DEqNJexEb/2pKPtdXNLcr72aJtfl6whA=="
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.4.tgz",
+      "integrity": "sha512-XSEM1jjL9CPI4pZ0RZs84Oq+jcONXFHljufxrp70rTYTbslDuYDj1wnDCzDb3XC9Tf5C36sGO1Fu7VFXXDTgFw=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
@@ -2879,6 +2879,19 @@
       },
       "optionalDependencies": {
         "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@skarab/tson/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@toi/toi": {
@@ -6088,6 +6101,30 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "peer": true
     },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -6412,9 +6449,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -7406,7 +7443,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7570,7 +7606,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7752,9 +7787,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -8761,11 +8799,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -9038,10 +9076,9 @@
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10157,6 +10194,23 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
+    "node_modules/ts-patch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.0.1.tgz",
+      "integrity": "sha512-FH61Ywi3A9nBQmWU7GGA35TKoQzkkqkwpUzGixybWJ0KSeIVWUzFSX7JPCBEJcMLdXX/A3Jtdhp2tcVgMwaTtA==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "global-prefix": "^3.0.0",
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.2",
+        "semver": "^7.3.8",
+        "strip-ansi": "^6.0.1"
+      },
+      "bin": {
+        "ts-patch": "bin/ts-patch.js",
+        "tspc": "bin/tspc.js"
+      }
+    },
     "node_modules/ts-railway": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/ts-railway/-/ts-railway-6.1.1.tgz",
@@ -10164,9 +10218,12 @@
       "dev": true
     },
     "node_modules/ts-runtime-checks": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ts-runtime-checks/-/ts-runtime-checks-0.1.3.tgz",
-      "integrity": "sha512-IM+LDo/wdi21wovcR2DnPpEVgxw9uXXwKygdYQTuImm2H2+6vmmFrFIZzxRTxaQNDiXkK0v2Gpgv+4hrhNQBUw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-runtime-checks/-/ts-runtime-checks-0.2.0.tgz",
+      "integrity": "sha512-OwUxacF+X72goT6wX6XWohCwhHmP42y7AwQYFg0R2eRoy/8NCKFuPlEIzpCPvcTGRipw06DaXk6YN7xnd3IKkA==",
+      "dependencies": {
+        "ts-patch": "^3.0.1"
+      }
     },
     "node_modules/ts-tiny-invariant": {
       "version": "2.0.4",
@@ -10204,22 +10261,6 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/ttypescript": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
-      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
-      "dependencies": {
-        "resolve": ">=1.9.0"
-      },
-      "bin": {
-        "ttsc": "bin/tsc",
-        "ttsserver": "bin/tsserver"
-      },
-      "peerDependencies": {
-        "ts-node": ">=8.0.2",
-        "typescript": ">=3.2.2"
       }
     },
     "node_modules/type-check": {
@@ -10265,21 +10306,21 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typia": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.1.tgz",
-      "integrity": "sha512-TzuuAMUU3qLeyFaddfOJI0+CTXmjGpciUQMFSjVi4mmzEvFjR2lYveJvkGtq1hu4nP7nDl0WII0i3UK01/aUiA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.6.tgz",
+      "integrity": "sha512-nUvhsOyRT/wEplRjczALmh839mYJrNLra6FfCrkMkFPjncuVqffTkgjKDqmX72GuFBN1TuU2rEnhnJRwsW419w==",
       "dependencies": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
@@ -11160,8 +11201,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -13288,9 +13328,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.28.18",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.28.18.tgz",
-      "integrity": "sha512-I19d36CXlLAsm+nrl7VKsYyirFLtdebT2nlfV3Knvo0tnk8B8UKyt3DEqNJexEb/2pKPtdXNLcr72aJtfl6whA=="
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.4.tgz",
+      "integrity": "sha512-XSEM1jjL9CPI4pZ0RZs84Oq+jcONXFHljufxrp70rTYTbslDuYDj1wnDCzDb3XC9Tf5C36sGO1Fu7VFXXDTgFw=="
     },
     "@sinonjs/commons": {
       "version": "2.0.0",
@@ -13316,6 +13356,14 @@
       "integrity": "sha512-DZMeweKar8axpt9OtW+8OW7GmAQELM0IBiDHkz1/rkzkW0MR9VmIiKNMx7TP2BxonZnDIaUtEXB47eOU5oRRpw==",
       "requires": {
         "typescript": "^4.6.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "optional": true
+        }
       }
     },
     "@toi/toi": {
@@ -15710,6 +15758,26 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "peer": true
     },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -15942,9 +16010,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -16685,8 +16753,7 @@
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "4.1.4",
@@ -16817,7 +16884,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -16952,9 +17018,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -17706,11 +17772,11 @@
       "requires": {}
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -17904,10 +17970,9 @@
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -18736,6 +18801,19 @@
         }
       }
     },
+    "ts-patch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.0.1.tgz",
+      "integrity": "sha512-FH61Ywi3A9nBQmWU7GGA35TKoQzkkqkwpUzGixybWJ0KSeIVWUzFSX7JPCBEJcMLdXX/A3Jtdhp2tcVgMwaTtA==",
+      "requires": {
+        "chalk": "^4.1.2",
+        "global-prefix": "^3.0.0",
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.2",
+        "semver": "^7.3.8",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "ts-railway": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/ts-railway/-/ts-railway-6.1.1.tgz",
@@ -18743,9 +18821,12 @@
       "dev": true
     },
     "ts-runtime-checks": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ts-runtime-checks/-/ts-runtime-checks-0.1.3.tgz",
-      "integrity": "sha512-IM+LDo/wdi21wovcR2DnPpEVgxw9uXXwKygdYQTuImm2H2+6vmmFrFIZzxRTxaQNDiXkK0v2Gpgv+4hrhNQBUw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-runtime-checks/-/ts-runtime-checks-0.2.0.tgz",
+      "integrity": "sha512-OwUxacF+X72goT6wX6XWohCwhHmP42y7AwQYFg0R2eRoy/8NCKFuPlEIzpCPvcTGRipw06DaXk6YN7xnd3IKkA==",
+      "requires": {
+        "ts-patch": "^3.0.1"
+      }
     },
     "ts-tiny-invariant": {
       "version": "2.0.4",
@@ -18779,14 +18860,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "ttypescript": {
-      "version": "1.5.15",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
-      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
-      "requires": {
-        "resolve": ">=1.9.0"
-      }
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -18818,14 +18891,14 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
     },
     "typia": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.1.tgz",
-      "integrity": "sha512-TzuuAMUU3qLeyFaddfOJI0+CTXmjGpciUQMFSjVi4mmzEvFjR2lYveJvkGtq1hu4nP7nDl0WII0i3UK01/aUiA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-4.1.6.tgz",
+      "integrity": "sha512-nUvhsOyRT/wEplRjczALmh839mYJrNLra6FfCrkMkFPjncuVqffTkgjKDqmX72GuFBN1TuU2rEnhnJRwsW419w==",
       "requires": {
         "commander": "^10.0.0",
         "comment-json": "^4.2.3",
@@ -19572,8 +19645,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "docs:watch": "tsc --project tsconfig.docs.json --watch --preserveWatchOutput & serve docs",
     "docs:build": "tsc --project tsconfig.docs.json",
     "compile:spectypes": "rimraf cases/spectypes/build && tsc -p cases/spectypes/src && babel cases/spectypes/src --out-dir cases/spectypes/build --extensions \".ts\"",
-    "compile:ts-runtime-checks": "rimraf cases/ts-runtime-checks/build && ttsc -p cases/ts-runtime-checks/src",
-    "compile:typia": "rimraf cases/typia/build && ttsc -p cases/typia/tsconfig.json"
+    "compile:ts-runtime-checks": "rimraf cases/ts-runtime-checks/build && tsc -p cases/ts-runtime-checks/src",
+    "compile:typia": "rimraf cases/typia/build && tsc -p cases/typia/tsconfig.json",
+    "prepare": "ts-patch install"
   },
   "dependencies": {
     "@ailabs/ts-utils": "1.4.0",
     "@badrap/valita": "0.2.1",
     "@mojotech/json-type-validation": "3.1.0",
     "@sapphire/shapeshift": "3.9.2",
-    "@sinclair/typebox": "0.28.18",
+    "@sinclair/typebox": "0.29.4",
     "@skarab/tson": "1.5.1",
     "@toi/toi": "1.3.0",
     "@typeofweb/schema": "0.7.3",
@@ -67,10 +68,9 @@
     "ts-interface-checker": "1.0.2",
     "ts-json-validator": "0.7.1",
     "ts-node": "10.9.1",
-    "ts-runtime-checks": "0.1.3",
-    "ttypescript": "1.5.15",
-    "typescript": "4.9.5",
-    "typia": "4.1.1",
+    "ts-runtime-checks": "0.2.0",
+    "typescript": "5.1.6",
+    "typia": "4.1.6",
     "vality": "6.3.3",
     "vega": "5.25.0",
     "vega-lite": "5.11.0",
@@ -93,6 +93,7 @@
     "jest": "29.5.0",
     "rimraf": "5.0.1",
     "ts-jest": "29.1.0",
+    "ts-patch": "^3.0.1",
     "tsconfigs": "4.0.2"
   },
   "keywords": [


### PR DESCRIPTION
Especially, `ts-runtime-checks` had a great change that performing exact object type validation.

  - Previous: `typeof obj === "object"`
  - Current: `typeof object === "object" && obj !== null`

By the way, the new version of `ts-runtime-checks` requires the latest TypeScript v5 version. And its based compiler `ttypescript` had been deprecated since `typescript@5` version, and `ts-patch` is continuing the project. Therefore, upgraded to `typescript@5`, and adopted `ts-patch`.

The other updates `typia` and `typebox`, it doesn't have special change on performance, but did because I know \o/.