### PR TITLE
feat: add valibot

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 * [Vality](https://github.com/jeengbe/vality)
 * [yup](https://github.com/jquense/yup)
 * [zod](https://github.com/vriad/zod)
+* [valibot](https://github.com/fabian-hiller/valibot)
 
 ## Criteria
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@
 * [ts-utils](https://github.com/ai-labs-team/ts-utils)
 * [typia](https://github.com/samchon/typia)
 * [@typeofweb/schema](https://github.com/typeofweb/schema)
+* [valibot](https://github.com/fabian-hiller/valibot)
 * [valita](https://github.com/badrap/valita)
 * [Vality](https://github.com/jeengbe/vality)
 * [yup](https://github.com/jquense/yup)
 * [zod](https://github.com/vriad/zod)
-* [valibot](https://github.com/fabian-hiller/valibot)
 
 ## Criteria
 

--- a/cases/valibot.ts
+++ b/cases/valibot.ts
@@ -22,24 +22,25 @@ createCase('valibot', 'parseSafe', () => {
 });
 
 createCase('valibot', 'parseStrict', () => {
-  const dataType = v.strict(v
-    .object({
+  const dataType = v.strict(
+    v.object({
       number: v.number(),
       negNumber: v.number(),
       maxNumber: v.number(),
       string: v.string(),
       longString: v.string(),
       boolean: v.boolean(),
-      deeplyNested: v.strict(v
-        .object({
+      deeplyNested: v.strict(
+        v.object({
           foo: v.string(),
           num: v.number(),
           bool: v.boolean(),
-        }))
-    }))
+        })
+      ),
+    })
+  );
 
   return data => {
-    return v.safeParse(dataType, data)
+    return v.safeParse(dataType, data);
   };
 });
-

--- a/cases/valibot.ts
+++ b/cases/valibot.ts
@@ -41,6 +41,6 @@ createCase('valibot', 'parseStrict', () => {
   );
 
   return data => {
-    return v.safeParse(dataType, data);
+    return dataType.parse(data);
   };
 });

--- a/cases/valibot.ts
+++ b/cases/valibot.ts
@@ -1,0 +1,45 @@
+import * as v from 'valibot';
+import { createCase } from '../benchmarks';
+
+createCase('valibot', 'parseSafe', () => {
+  const dataType = v.object({
+    number: v.number(),
+    negNumber: v.number(),
+    maxNumber: v.number(),
+    string: v.string(),
+    longString: v.string(),
+    boolean: v.boolean(),
+    deeplyNested: v.object({
+      foo: v.string(),
+      num: v.number(),
+      bool: v.boolean(),
+    }),
+  });
+
+  return data => {
+    return dataType.parse(data);
+  };
+});
+
+createCase('valibot', 'parseStrict', () => {
+  const dataType = v.strict(v
+    .object({
+      number: v.number(),
+      negNumber: v.number(),
+      maxNumber: v.number(),
+      string: v.string(),
+      longString: v.string(),
+      boolean: v.boolean(),
+      deeplyNested: v.strict(v
+        .object({
+          foo: v.string(),
+          num: v.number(),
+          bool: v.boolean(),
+        }))
+    }))
+
+  return data => {
+    return v.safeParse(dataType, data)
+  };
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "ts-runtime-checks": "0.2.0",
         "typescript": "5.1.6",
         "typia": "4.1.6",
+        "valibot": "0.8.0",
         "vality": "6.3.3",
         "vega": "5.25.0",
         "vega-lite": "5.11.0",
@@ -10529,6 +10530,11 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/valibot": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.8.0.tgz",
+      "integrity": "sha512-wQHXVkVFj6Z0R3297icGCp3UX8S66onuIg03ihJ8aVgMn8pMJvYSfmrKb+aIg7w/Aw08togrklaMSqDP2vKtIA=="
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -19041,6 +19047,11 @@
           }
         }
       }
+    },
+    "valibot": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.8.0.tgz",
+      "integrity": "sha512-wQHXVkVFj6Z0R3297icGCp3UX8S66onuIg03ihJ8aVgMn8pMJvYSfmrKb+aIg7w/Aw08togrklaMSqDP2vKtIA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ts-runtime-checks": "0.2.0",
     "typescript": "5.1.6",
     "typia": "4.1.6",
+    "valibot": "0.8.0",
     "vality": "6.3.3",
     "vega": "5.25.0",
     "vega-lite": "5.11.0",


### PR DESCRIPTION
We might want to wait for https://github.com/fabian-hiller/valibot/pull/46 to be resolved since I expect that could improve the performance a lot


## (Benchmark on my MacBook Air M2)

I ran `npm run start run valibot`:

Against `valibot@0.8.0`:
```
Removing previous results
Executing "valibot"
Loading "valibot"
Running "parseSafe" suite...
Progress: 100%

  valibot:
    303 700 ops/s, ±2.28%   | fastest

Finished 1 case!
Running "parseStrict" suite...
Progress: 100%

  valibot:
    338 906 ops/s, ±2.54%   | fastest

Finished 1 case!
```


Against https://github.com/fabian-hiller/valibot/pull/46:
```
Removing previous results
Executing "valibot"
Loading "valibot"
Running "parseSafe" suite...
Progress: 100%

  valibot:
    659 443 ops/s, ±1.68%   | fastest

Finished 1 case!
Running "parseStrict" suite...
Progress: 100%

  valibot:
    691 575 ops/s, ±1.99%   | fastest

Finished 1 case!
```

Closes #1104