### PR TITLE
Make valibot appear in benchmarks

### DIFF
--- a/cases/index.ts
+++ b/cases/index.ts
@@ -32,6 +32,7 @@ export const cases = [
   'tson',
   'typeofweb-schema',
   'typia',
+  'valibot',
   'valita',
   'vality',
   'yup',

--- a/test/benchmarks.test.ts
+++ b/test/benchmarks.test.ts
@@ -36,6 +36,7 @@ import '../cases/ts-utils';
 import '../cases/tson';
 import '../cases/typeofweb-schema';
 import '../cases/typia';
+import '../cases/valibot';
 import '../cases/valita';
 import '../cases/vality';
 import '../cases/yup';


### PR DESCRIPTION
This is a follow up for https://github.com/moltar/typescript-runtime-type-benchmarks/pull/1112