### PR TITLE
chore: Use the correct API for Valibot (it should not affect perf)

### DIFF
--- a/cases/valibot.ts
+++ b/cases/valibot.ts
@@ -17,7 +17,7 @@ createCase('valibot', 'parseSafe', () => {
   });
 
   return data => {
-    return dataType.parse(data);
+    return v.parse(dataType, data);
   };
 });
 
@@ -41,6 +41,6 @@ createCase('valibot', 'parseStrict', () => {
   );
 
   return data => {
-    return dataType.parse(data);
+    return v.parse(dataType, data);
   };
 });


### PR DESCRIPTION
cc: @fabian-hiller

`.parse()` on the Valibot schema was never intended to be used directly. 

I did not notice this while I did the change in https://github.com/moltar/typescript-runtime-type-benchmarks/pull/1112 since I was just relying on auto completion based on TypeScript types and `.parse` appeared. 

Note that the future version of Valibot [renamed it to `_parse`](https://github.com/fabian-hiller/valibot/blob/db2714403351b469eed8c8622613af5067db9514/library/src/schemas/object/object.ts#L93-L93) to avoid this confusion.

Anyway let's use the intended documented API. Otherwise, updating Valibot version in the future will break this test case. Note that this should not affect performance since internally it's just calling the `.parse` on the schema now.