### PR TITLE
Update `valibot` to `0.13.0`

### DIFF
--- a/cases/valibot.ts
+++ b/cases/valibot.ts
@@ -1,46 +1,46 @@
-import * as v from 'valibot';
+import { object, number, string, boolean, parse, strict } from 'valibot';
 import { createCase } from '../benchmarks';
 
 createCase('valibot', 'parseSafe', () => {
-  const dataType = v.object({
-    number: v.number(),
-    negNumber: v.number(),
-    maxNumber: v.number(),
-    string: v.string(),
-    longString: v.string(),
-    boolean: v.boolean(),
-    deeplyNested: v.object({
-      foo: v.string(),
-      num: v.number(),
-      bool: v.boolean(),
+  const dataType = object({
+    number: number(),
+    negNumber: number(),
+    maxNumber: number(),
+    string: string(),
+    longString: string(),
+    boolean: boolean(),
+    deeplyNested: object({
+      foo: string(),
+      num: number(),
+      bool: boolean(),
     }),
   });
 
   return data => {
-    return v.parse(dataType, data);
+    return parse(dataType, data);
   };
 });
 
 createCase('valibot', 'parseStrict', () => {
-  const dataType = v.strict(
-    v.object({
-      number: v.number(),
-      negNumber: v.number(),
-      maxNumber: v.number(),
-      string: v.string(),
-      longString: v.string(),
-      boolean: v.boolean(),
-      deeplyNested: v.strict(
-        v.object({
-          foo: v.string(),
-          num: v.number(),
-          bool: v.boolean(),
+  const dataType = strict(
+    object({
+      number: number(),
+      negNumber: number(),
+      maxNumber: number(),
+      string: string(),
+      longString: string(),
+      boolean: boolean(),
+      deeplyNested: strict(
+        object({
+          foo: string(),
+          num: number(),
+          bool: boolean(),
         })
       ),
     })
   );
 
   return data => {
-    return v.parse(dataType, data);
+    return parse(dataType, data);
   };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "ts-runtime-checks": "0.2.0",
         "typescript": "5.1.6",
         "typia": "4.1.16",
-        "valibot": "0.8.0",
+        "valibot": "0.13.0",
         "vality": "6.3.3",
         "vega": "5.25.0",
         "vega-lite": "5.11.0",
@@ -10035,9 +10035,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.8.0.tgz",
-      "integrity": "sha512-wQHXVkVFj6Z0R3297icGCp3UX8S66onuIg03ihJ8aVgMn8pMJvYSfmrKb+aIg7w/Aw08togrklaMSqDP2vKtIA=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.13.0.tgz",
+      "integrity": "sha512-okhEagJrmgpWW0QAarQpL7lJ6TszCjJcZAgpNx/bxvrK2hrdDevTPIK1AkiVE/wLBateLUgQX6PTLAezN9L1XA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -18050,9 +18050,9 @@
       }
     },
     "valibot": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.8.0.tgz",
-      "integrity": "sha512-wQHXVkVFj6Z0R3297icGCp3UX8S66onuIg03ihJ8aVgMn8pMJvYSfmrKb+aIg7w/Aw08togrklaMSqDP2vKtIA=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.13.0.tgz",
+      "integrity": "sha512-okhEagJrmgpWW0QAarQpL7lJ6TszCjJcZAgpNx/bxvrK2hrdDevTPIK1AkiVE/wLBateLUgQX6PTLAezN9L1XA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ts-runtime-checks": "0.2.0",
     "typescript": "5.1.6",
     "typia": "4.1.16",
-    "valibot": "0.8.0",
+    "valibot": "0.13.0",
     "vality": "6.3.3",
     "vega": "5.25.0",
     "vega-lite": "5.11.0",


### PR DESCRIPTION
- this update has a significant performance increase associated with it
- also updating `valibot` imports to use tree shaking import pattern

## `0.13.0` benchmark

```shell
Running "parseSafe" suite...
Progress: 100%

  valibot:
    2 029 764 ops/s, ±1.17%   | fastest

Finished 1 case!
Running "parseStrict" suite...
Progress: 100%

  valibot:
    1 982 199 ops/s, ±0.96%   | fastest
```

## `0.8.0` benchmark

```shell
$ npm run start run valibot

Running "parseSafe" suite...
Progress: 100%

  valibot:
    129 373 ops/s, ±3.78%   | fastest

Finished 1 case!
Running "parseStrict" suite...
Progress: 100%

  valibot:
    145 368 ops/s, ±3.69%   | fastest
```

