### PR TITLE
Honest benchmark callback

### DIFF
--- a/cases/deepkit/index.ts
+++ b/cases/deepkit/index.ts
@@ -1,5 +1,9 @@
 import { parseSafe, assertLoose } from './build';
 import { addCase } from '../../benchmarks';
 
-addCase('deepkit', 'parseSafe', parseSafe);
-addCase('deepkit', 'assertLoose', assertLoose);
+addCase('deepkit', 'parseSafe', (data) => {
+  return parseSafe(data);
+});
+addCase('deepkit', 'assertLoose', (data) => {
+  return assertLoose(data);
+});

--- a/cases/deepkit/index.ts
+++ b/cases/deepkit/index.ts
@@ -1,9 +1,9 @@
 import { parseSafe, assertLoose } from './build';
 import { addCase } from '../../benchmarks';
 
-addCase('deepkit', 'parseSafe', (data) => {
+addCase('deepkit', 'parseSafe', data => {
   return parseSafe(data);
 });
-addCase('deepkit', 'assertLoose', (data) => {
+addCase('deepkit', 'assertLoose', data => {
   return assertLoose(data);
 });

--- a/cases/mol_data.ts
+++ b/cases/mol_data.ts
@@ -8,7 +8,7 @@ import {
 import { createCase } from '../benchmarks';
 
 createCase('$mol_data', 'parseSafe', () => {
-  return Rec({
+  const dataType = Rec({
     number: Numb,
     negNumber: Numb,
     maxNumber: Numb,
@@ -21,6 +21,11 @@ createCase('$mol_data', 'parseSafe', () => {
       bool: Bool,
     }),
   });
+
+  return data => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return dataType(data as any);
+  };
 });
 
 createCase('$mol_data', 'assertLoose', () => {

--- a/cases/ts-runtime-checks/index.ts
+++ b/cases/ts-runtime-checks/index.ts
@@ -1,8 +1,17 @@
 import { assertStrict, assertLoose, parseStrict } from './build';
 import { addCase } from '../../benchmarks';
 
-addCase('ts-runtime-checks', 'parseStrict', parseStrict);
+addCase('ts-runtime-checks', 'parseStrict', data => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return parseStrict(data as any)
+});
 
-addCase('ts-runtime-checks', 'assertStrict', assertStrict);
+addCase('ts-runtime-checks', 'assertStrict', (data) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return assertStrict(data as any);
+});
 
-addCase('ts-runtime-checks', 'assertLoose', assertLoose);
+addCase('ts-runtime-checks', 'assertLoose', (data) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return assertLoose(data as any);
+});

--- a/cases/ts-runtime-checks/index.ts
+++ b/cases/ts-runtime-checks/index.ts
@@ -3,15 +3,15 @@ import { addCase } from '../../benchmarks';
 
 addCase('ts-runtime-checks', 'parseStrict', data => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return parseStrict(data as any)
+  return parseStrict(data as any);
 });
 
-addCase('ts-runtime-checks', 'assertStrict', (data) => {
+addCase('ts-runtime-checks', 'assertStrict', data => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return assertStrict(data as any);
 });
 
-addCase('ts-runtime-checks', 'assertLoose', (data) => {
+addCase('ts-runtime-checks', 'assertLoose', data => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return assertLoose(data as any);
 });

--- a/cases/typia/index.ts
+++ b/cases/typia/index.ts
@@ -1,7 +1,19 @@
-import { parseSafe, parseStrict, assertLoose, assertStrict } from './build';
+import { is, equals, clone } from './build';
 import { addCase } from '../../benchmarks';
 
-addCase('typia', 'parseSafe', parseSafe);
-addCase('typia', 'parseStrict', parseStrict);
-addCase('typia', 'assertStrict', assertStrict);
-addCase('typia', 'assertLoose', assertLoose);
+addCase('typia', 'parseSafe', (data) => {
+  if (!is(data)) throw new Error('wrong type.');
+  return clone(data);
+});
+addCase('typia', 'parseStrict', (data) => {
+  if (!equals(data)) throw new Error('wrong type.');
+  return data;
+});
+addCase('typia', 'assertStrict', (data)=> {
+  if (!equals(data)) throw new Error('wrong type.');
+  return true;
+});
+addCase('typia', 'assertLoose', (data) => {
+  if (!is(data)) throw new Error('wrong type.');
+  return true;
+});

--- a/cases/typia/index.ts
+++ b/cases/typia/index.ts
@@ -1,19 +1,19 @@
 import { is, equals, clone } from './build';
 import { addCase } from '../../benchmarks';
 
-addCase('typia', 'parseSafe', (data) => {
+addCase('typia', 'parseSafe', data => {
   if (!is(data)) throw new Error('wrong type.');
   return clone(data);
 });
-addCase('typia', 'parseStrict', (data) => {
+addCase('typia', 'parseStrict', data => {
   if (!equals(data)) throw new Error('wrong type.');
   return data;
 });
-addCase('typia', 'assertStrict', (data)=> {
+addCase('typia', 'assertStrict', data => {
   if (!equals(data)) throw new Error('wrong type.');
   return true;
 });
-addCase('typia', 'assertLoose', (data) => {
+addCase('typia', 'assertLoose', data => {
   if (!is(data)) throw new Error('wrong type.');
   return true;
 });

--- a/cases/typia/src/index.ts
+++ b/cases/typia/src/index.ts
@@ -17,4 +17,3 @@ interface ToBeChecked {
 export const is = typia.createIs<ToBeChecked>();
 export const equals = typia.createEquals<ToBeChecked>();
 export const clone = typia.misc.createClone<ToBeChecked>();
-

--- a/cases/typia/src/index.ts
+++ b/cases/typia/src/index.ts
@@ -14,26 +14,7 @@ interface ToBeChecked {
   };
 }
 
-const is = typia.createIs<ToBeChecked>();
-const equals = typia.createEquals<ToBeChecked>();
-const clone = typia.misc.createClone<ToBeChecked>();
+export const is = typia.createIs<ToBeChecked>();
+export const equals = typia.createEquals<ToBeChecked>();
+export const clone = typia.misc.createClone<ToBeChecked>();
 
-export function assertLoose(input: unknown): boolean {
-  if (!is(input)) throw new Error('wrong type.');
-  return true;
-}
-
-export function assertStrict(input: unknown): boolean {
-  if (!equals(input)) throw new Error('wrong type.');
-  return true;
-}
-
-export function parseStrict(input: unknown): ToBeChecked {
-  if (!equals(input)) throw new Error('wrong type.');
-  return input;
-}
-
-export function parseSafe(input: unknown): ToBeChecked {
-  if (!is(input)) throw new Error('wrong type.');
-  return clone(input);
-}


### PR DESCRIPTION
I noticed that for some libraries, the operation is inlined instead of being called inside the benchmark callback.
Since there are many libraries that could be potentially inlined like this eg Zod, but they still used the benchmark callback, I've decided to walk through all the libraries that don't use it and fix them. I think it'll make the benchmark more honest.