### PR TITLE
Bump up `typia` version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "ts-node": "10.9.2",
         "ts-runtime-checks": "0.4.1",
         "typescript": "5.5.4",
-        "typia": "6.7.0",
+        "typia": "6.7.2",
         "unknownutil": "3.11.0",
         "valibot": "0.21.0",
         "vality": "6.3.4",
@@ -10040,9 +10040,9 @@
       }
     },
     "node_modules/typia": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-6.7.0.tgz",
-      "integrity": "sha512-lXipD7asf2TSYPAT8ZkTzcV5E7ophz2Q+TxD+8nQLb/v+Mzj4UxOAr7Twf7ODc4HXe80dfLPuf3amkqbLIvuSA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-6.7.2.tgz",
+      "integrity": "sha512-FP3VBdEu9yPFeUg4TYFKh055HNZJjQbr1WyWdyNjhG/Vb4TxRDtcx5v1JDqaje4XvJe8TGLeozH4QutQQUy8Sw==",
       "dependencies": {
         "@samchon/openapi": "^0.4.3",
         "commander": "^10.0.0",
@@ -18192,9 +18192,9 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
     },
     "typia": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/typia/-/typia-6.7.0.tgz",
-      "integrity": "sha512-lXipD7asf2TSYPAT8ZkTzcV5E7ophz2Q+TxD+8nQLb/v+Mzj4UxOAr7Twf7ODc4HXe80dfLPuf3amkqbLIvuSA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/typia/-/typia-6.7.2.tgz",
+      "integrity": "sha512-FP3VBdEu9yPFeUg4TYFKh055HNZJjQbr1WyWdyNjhG/Vb4TxRDtcx5v1JDqaje4XvJe8TGLeozH4QutQQUy8Sw==",
       "requires": {
         "@samchon/openapi": "^0.4.3",
         "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ts-node": "10.9.2",
     "ts-runtime-checks": "0.4.1",
     "typescript": "5.5.4",
-    "typia": "6.7.0",
+    "typia": "6.7.1",
     "unknownutil": "3.11.0",
     "valibot": "0.21.0",
     "vality": "6.3.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ts-node": "10.9.2",
     "ts-runtime-checks": "0.4.1",
     "typescript": "5.5.4",
-    "typia": "6.7.1",
+    "typia": "6.7.2",
     "unknownutil": "3.11.0",
     "valibot": "0.21.0",
     "vality": "6.3.4",


### PR DESCRIPTION
Just optimized `typia.misc.clone()` function a little bit, so that `safeParse()` benchmark of `typia` would be a little bit faster.

https://github.com/samchon/typia/pull/1197