### PR TITLE
Fastest sort by default

### DIFF
--- a/docs/app.tsx
+++ b/docs/app.tsx
@@ -222,11 +222,11 @@ async function graph({
   // build a list of module names for sorting
   let sortedValues: BenchmarkResult[] = [];
 
-  if (sort === 'fastest') {
+  if (sort === 'fastest' || !sort) {
     sortedValues = [...valuesNodejs, ...valuesBun].sort(
       (a, b) => b.ops - a.ops
     );
-  } else if (sort === 'alphabetically' || !sort) {
+  } else if (sort === 'alphabetically') {
     sortedValues = [...valuesNodejs, ...valuesBun].sort((a, b) =>
       a.name < b.name ? -1 : 1
     );
@@ -437,7 +437,7 @@ class App extends Component<
     selectedBunVersions: {},
     valuesNodeJs: [],
     valuesBun: [],
-    sortBy: 'alphabetically' as const,
+    sortBy: 'fastest' as const,
   };
 
   getNodeJsVersions() {
@@ -645,8 +645,8 @@ class App extends Component<
                 }
                 value={this.state.sortBy}
               >
-                <option value="alphabetically">Alphabetically</option>
                 <option value="fastest">Fastest</option>
+                <option value="alphabetically">Alphabetically</option>
               </select>
             </label>
           </div>

--- a/docs/dist/app.js
+++ b/docs/dist/app.js
@@ -57,8 +57,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
-    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
@@ -194,11 +194,11 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
         return parseInt(match[1]);
     }
     function graph(_a) {
-        return __awaiter(this, arguments, void 0, function (_b) {
+        var selectedBenchmarks = _a.selectedBenchmarks, selectedNodeJsVersions = _a.selectedNodeJsVersions, selectedBunVersions = _a.selectedBunVersions, benchmarkResultsNodejs = _a.benchmarkResultsNodejs, benchmarkResultsBun = _a.benchmarkResultsBun, sort = _a.sort;
+        return __awaiter(this, void 0, void 0, function () {
             var selectedBenchmarkSet, selectedNodeJsVersionsSet, selectedBunVersionsSet, valuesNodejs, valuesBun, nodeJsVersionCount, bunVersionCount, colorScaleRange, sortedValues, sortedNames, vegaSpec, view, svg;
-            var selectedBenchmarks = _b.selectedBenchmarks, selectedNodeJsVersions = _b.selectedNodeJsVersions, selectedBunVersions = _b.selectedBunVersions, benchmarkResultsNodejs = _b.benchmarkResultsNodejs, benchmarkResultsBun = _b.benchmarkResultsBun, sort = _b.sort;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
+            return __generator(this, function (_b) {
+                switch (_b.label) {
                     case 0:
                         if (!selectedBenchmarks.length ||
                             (!selectedNodeJsVersions.length && !selectedBunVersions.length)) {
@@ -250,10 +250,10 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
                             }
                         });
                         sortedValues = [];
-                        if (sort === 'fastest') {
+                        if (sort === 'fastest' || !sort) {
                             sortedValues = __spreadArray(__spreadArray([], valuesNodejs, true), valuesBun, true).sort(function (a, b) { return b.ops - a.ops; });
                         }
-                        else if (sort === 'alphabetically' || !sort) {
+                        else if (sort === 'alphabetically') {
                             sortedValues = __spreadArray(__spreadArray([], valuesNodejs, true), valuesBun, true).sort(function (a, b) {
                                 return a.name < b.name ? -1 : 1;
                             });
@@ -265,7 +265,7 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
                                 values: __spreadArray(__spreadArray([], valuesNodejs, true), valuesBun, true),
                             },
                             height: { step: 15 / (nodeJsVersionCount + bunVersionCount) },
-                            background: 'transparent', // no white graphs for dark mode users
+                            background: 'transparent',
                             facet: {
                                 row: {
                                     field: 'name',
@@ -331,7 +331,7 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
                         view = new vega.View(vega.parse(vegaSpec.spec), { renderer: 'none' });
                         return [4 /*yield*/, view.toSVG()];
                     case 1:
-                        svg = _c.sent();
+                        svg = _b.sent();
                         return [2 /*return*/, svg];
                 }
             });
@@ -416,7 +416,7 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
                 selectedBunVersions: {},
                 valuesNodeJs: [],
                 valuesBun: [],
-                sortBy: 'alphabetically',
+                sortBy: 'fastest',
             };
             return _this;
         }
@@ -524,8 +524,8 @@ define("app", ["require", "exports", "preact", "vega", "vega-lite"], function (r
                                 function (event) {
                                     _this.setState({ sortBy: event.target.value });
                                 }, value: this.state.sortBy },
-                                (0, preact_1.h)("option", { value: "alphabetically" }, "Alphabetically"),
-                                (0, preact_1.h)("option", { value: "fastest" }, "Fastest"))))),
+                                (0, preact_1.h)("option", { value: "fastest" }, "Fastest"),
+                                (0, preact_1.h)("option", { value: "alphabetically" }, "Alphabetically"))))),
                 (0, preact_1.h)(Graph, { benchmarks: BENCHMARKS.filter(function (b) { return _this.state.selectedBenchmarks[b.name]; }), nodeJsVersions: Object.entries(this.state.selectedNodeJsVersions)
                         .sort()
                         .filter(function (entry) { return entry[1]; })


### PR DESCRIPTION
I think it makes sense for a benchmark to have sorted by fastest enabled by default. At least this is what I always choose whenever I open the benchmark.

<img width="929" alt="image" src="https://github.com/user-attachments/assets/26d4022f-02d5-42ee-936d-a90f17281a4f">
