### PR TITLE
fix ordering issue when both node and bun are selected

### DIFF
--- a/docs/app.tsx
+++ b/docs/app.tsx
@@ -178,6 +178,11 @@ async function graph({
   const selectedNodeJsVersionsSet = new Set(selectedNodeJsVersions);
   const selectedBunVersionsSet = new Set(selectedBunVersions);
 
+  const runtimesOrder = {
+    NODE: 0,
+    BUN: 1,
+  };
+
   const valuesNodejs = benchmarkResultsNodejs
     .filter(
       b =>
@@ -190,6 +195,7 @@ async function graph({
       // artificical benchmark name to make sure its always sorted by
       // benchmark and node-version
       benchmark: [
+        runtimesOrder.NODE,
         BENCHMARKS_ORDER[b.benchmark],
         NODE_VERSIONS.indexOf(getNodeMajorVersionNumber(b.runtimeVersion)),
         b.runtimeVersion,
@@ -209,6 +215,7 @@ async function graph({
       // artificical benchmark name to make sure its always sorted by
       // benchmark and node-version
       benchmark: [
+        runtimesOrder.BUN,
         BENCHMARKS_ORDER[b.benchmark],
         BUN_VERSIONS.indexOf(getBunMajorVersionNumber(b.runtimeVersion)),
         b.runtimeVersion,


### PR DESCRIPTION
When selecting both node and bun the bars order and color was wrong:
![image](https://github.com/user-attachments/assets/6088e8c6-1ed2-42c1-be1e-fb942bbe2ae7)

This happened because the artificial name used to maintain the order didn't distinguish between node and bun.

In this PR I add another number at the beginning to separate node and bun:
![image](https://github.com/user-attachments/assets/f4029e41-28f6-4498-8f24-b6492d506cf8)
