### PR TITLE
Pleonov/add minification to type predicate generator

### DIFF
--- a/cases/type-predicate-generator/compile.sh
+++ b/cases/type-predicate-generator/compile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+cd "$(dirname "$0")"
+
+rimraf src/index_guards.ts
+type-predicate-generator ./src/index.ts
+
+rimraf build/
+tsc -p tsconfig.json

--- a/cases/type-predicate-generator/compile.sh
+++ b/cases/type-predicate-generator/compile.sh
@@ -14,3 +14,7 @@ type-predicate-generator src/index.ts
 rimraf build/
 # type check and compile to JS
 tsc -p tsconfig.json
+# minify the resulting compiled source
+esbuild --loader=js --minify < build/index_guards.js > build/index_guards.min.js
+rimraf build/index_guards.js
+mv build/index_guards.min.js build/index_guards.js

--- a/cases/type-predicate-generator/compile.sh
+++ b/cases/type-predicate-generator/compile.sh
@@ -2,10 +2,15 @@
 
 set -eux -o pipefail
 
+# jump into the current script directory
 cd "$(dirname "$0")"
 
+# remove the old predicate file if exists
 rimraf src/index_guards.ts
-type-predicate-generator ./src/index.ts
+# generate a new predicate file (src/index_guards.ts)
+type-predicate-generator src/index.ts
 
+# remove the old build files if exists
 rimraf build/
+# type check and compile to JS
 tsc -p tsconfig.json

--- a/cases/type-predicate-generator/index.ts
+++ b/cases/type-predicate-generator/index.ts
@@ -1,4 +1,8 @@
-import { isLoose } from './src/index_guards';
+// Importing a manually minified version because the test suite
+// is using ts-node that does not perform code minification
+// that Type Predicate Generator relies on for peak performance.
+// In GH codespace the numbers improved from 136.1M to 159.0M ops/s.
+import { isLoose } from './build/index_guards';
 import { addCase } from '../../benchmarks';
 
 addCase('type-predicate-generator', 'assertLoose', data => {

--- a/cases/type-predicate-generator/tsconfig.json
+++ b/cases/type-predicate-generator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "module": "commonjs",
     "outDir": "build",
     "strict": true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "compile:typebox": "ts-node cases/typebox/index.ts cases/typebox/build",
     "compile:typia": "rimraf cases/typia/build && tsc -p cases/typia/tsconfig.json",
     "compile:ts-auto-guard": "rimraf cases/ts-auto-guard/build && ts-auto-guard --project cases/ts-auto-guard/tsconfig.json && tsc -p cases/ts-auto-guard/tsconfig.json",
-    "compile:type-predicate-generator": "rimraf cases/type-predicate-generator/src/index_guards.ts && (cd cases/type-predicate-generator/src && type-predicate-generator ./index.ts) && tsc -p cases/type-predicate-generator/tsconfig.json",
+    "compile:type-predicate-generator": "./cases/type-predicate-generator/compile.sh",
     "prepare": "ts-patch install",
     "download-packages-popularity": "ts-node download-packages-popularity.ts"
   },


### PR DESCRIPTION
## Description

In this PR I'm following the lead of Paseri that also [relies on minification](https://github.com/moltar/typescript-runtime-type-benchmarks/blob/master/package.json#L22) for best performance (hey, if you're reading, thanks for discovering how to embed it into the benchmark!).

In my case the numbers jumped from 136M to 159M ops/s which is really sweet 😋

I'm also moving the script out of the `package.json` into a small shell script for readability. Please let me know if this is ok.

## Testing

Same as other changes, let's see if PR checks are green.

## Checklist

- [x] Conducted a self-review of the code changes.
- [ ] Updated documentation, if necessary.
- [ ] Added tests to validate the functionality or fix.
