### PR TITLE
feat: add parseSafe case for io-ts

### DIFF
--- a/cases/io-ts.ts
+++ b/cases/io-ts.ts
@@ -30,3 +30,31 @@ createCase('io-ts', 'assertLoose', () => {
     );
   };
 });
+
+createCase('io-ts', 'parseSafe', () => {
+  const dataType = t.strict({
+    number: t.Int,
+    negNumber: t.number,
+    maxNumber: t.number,
+    string: t.string,
+    longString: t.string,
+    boolean: t.boolean,
+    deeplyNested: t.strict({
+      foo: t.string,
+      num: t.number,
+      bool: t.boolean,
+    }),
+  });
+
+  return data => {
+    return pipe(
+      dataType.decode(data),
+      fold(
+        errors => {
+          throw errors;
+        },
+        result => result,
+      ),
+    );
+  };
+});


### PR DESCRIPTION
## Description

io-ts [provides a way](https://github.com/gcanti/io-ts/blob/master/index.md#exact-types) to do a _Safe Parsing_ test if you use the `exact` or `strict` function. This PR adds a test case for that.

## Testing

I believe the existing tests already cover the new case.

## Checklist

- [X] Conducted a self-review of the code changes.
- [X] Updated documentation, if necessary.
- [ ] Added tests to validate the functionality or fix.
