### PR TITLE
fix: skip failing benchmarks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,10 +61,24 @@ async function main() {
 
           console.log('Executing "%s"', c);
 
-          childProcess.execFileSync(cmd[0], cmd.slice(1), {
-            shell: false,
-            stdio: 'inherit',
-          });
+          try {
+            childProcess.execFileSync(cmd[0], cmd.slice(1), {
+              shell: false,
+              stdio: 'inherit',
+            });
+          } catch (e) {
+            // See #1611.
+            // Due to the wide range of modules and node versions that we
+            // benchmark these days, not every library supports every node
+            // version.
+            // So we ignore any benchmark that fails in order to not fail the
+            // whole run benchmark gh action. Their results will not be
+            // visible for this node version in the frontend.
+            // The better solution would be benchmark case metadata that lists
+            // compatible / node versions (e.g. for stnl sth like >= 23) and
+            // then skip incompatible node versions explicitly.
+            console.error('Skipped "%s" benchmark due to an error', c);
+          }
         }
       }
       break;


### PR DESCRIPTION
fixes #1611

## Description

Skip failing benchmarks to not block other benchmarks from running properly.

This is a quick fix to keep libraries in the list that do not support older node versions like stnl that only seems to work for node 23.

One potential downside / danger is that we have to look out for dependabot changes that update library versions that later fail to run. So this fix is only an intermediate solution. We should replace ts-node with something more modern in the near future.

## Testing

Check that even though stnl errors, the benchmark for valita still runs fine with node 22: `nvm use node 22; npm run start stnl valita`.

## Checklist

- [x] Conducted a self-review of the code changes: of course :grin: 
- [x] Updated documentation, if necessary: added inline comments
- [ ] Added tests to validate the functionality or fix: atm we don't have tests at all for benchmark infrastructure code


