### PR TITLE
ci: update Bun versions in workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,8 +61,7 @@ jobs:
         max-parallel: 3
         matrix:
           bun-version:
-            - 1.1.43
-            - 1.2.2
+            - 1.2.12
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
       max-parallel: 1
       matrix:
         bun-version:
-            - 1.1.43
-            - 1.2.2
+            - 1.2.12
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -6,7 +6,7 @@ import * as vegaLite from 'vega-lite';
 // the first is selected automatically
 const NODE_VERSIONS = [23, 22, 21, 20, 19, 18, 16];
 
-const BUN_VERSIONS = [1.2];
+const BUN_VERSIONS = [1.2, 1.1];
 
 const DENO_VERSIONS = [2];
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -6,7 +6,7 @@ import * as vegaLite from 'vega-lite';
 // the first is selected automatically
 const NODE_VERSIONS = [23, 22, 21, 20, 19, 18, 16];
 
-const BUN_VERSIONS = [1.2, 1.1];
+const BUN_VERSIONS = [1.2];
 
 const DENO_VERSIONS = [2];
 


### PR DESCRIPTION
## Description

Updates the Bun version matrix in GitHub workflows to use 1.2.12, removing older versions for consistency and alignment. Also refines the available Bun versions in documentation code to reflect these changes.

## Testing

CI

## Checklist

- [x] Conducted a self-review of the code changes.
