### PR TITLE
chore: update Node.js versions in CI workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,13 +14,11 @@ jobs:
       max-parallel: 3
       matrix:
         node-version:
-          - 16.x
-          - 18.x
-          - 19.x
           - 20.x
           - 21.x
           - 22.x
           - 23.x
+          - 24.x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,11 @@ jobs:
         #  - NODE_VERSIONS in app.tsx
         #  - NODE_VERSION_FOR_PREVIEW in main.ts
         node-version:
-          - 16.x
-          - 18.x
-          - 19.x
           - 20.x
           - 21.x
           - 22.x
           - 23.x
+          - 24.x
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -4,7 +4,7 @@ import * as vegaLite from 'vega-lite';
 
 // which results are attempted to load
 // the first is selected automatically
-const NODE_VERSIONS = [23, 22, 21, 20, 19, 18, 16];
+const NODE_VERSIONS = [24, 23, 22, 21, 20];
 
 const BUN_VERSIONS = [1.2, 1.1];
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -4,7 +4,7 @@ import * as vegaLite from 'vega-lite';
 
 // which results are attempted to load
 // the first is selected automatically
-const NODE_VERSIONS = [24, 23, 22, 21, 20, 19, 18, 16];
+const NODE_VERSIONS = [24, 23, 22, 21, 20];
 
 const BUN_VERSIONS = [1.2, 1.1];
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -4,7 +4,7 @@ import * as vegaLite from 'vega-lite';
 
 // which results are attempted to load
 // the first is selected automatically
-const NODE_VERSIONS = [24, 23, 22, 21, 20];
+const NODE_VERSIONS = [24, 23, 22, 21, 20, 19, 18, 16];
 
 const BUN_VERSIONS = [1.2, 1.1];
 


### PR DESCRIPTION
## Description

Removes support for Node.js versions 16.x to 19.x in both PR and release workflows. Adds support for Node.js 24.x to ensure alignment with the latest runtime environments. Updates NODE_VERSIONS constant to match supported versions.

## Testing

CI

## Checklist

- [x] Conducted a self-review of the code changes.
