### PR TITLE
Add arktype assertStrict and parseStrict benchmarks

### DIFF
--- a/cases/arktype.ts
+++ b/cases/arktype.ts
@@ -15,9 +15,28 @@ const t = type({
   },
 });
 
+const tStrict = t.onDeepUndeclaredKey('reject');
+
 createCase('arktype', 'assertLoose', () => {
   return data => {
     if (t.allows(data)) return true;
     throw new Error('Invalid');
+  };
+});
+
+createCase('arktype', 'assertStrict', () => {
+  return data => {
+    if (tStrict.allows(data)) return true;
+    throw new Error('Invalid');
+  };
+});
+
+createCase('arktype', 'parseStrict', () => {
+  return data => {
+    const out = tStrict(data);
+
+    if (out instanceof type.errors) throw new Error('Invalid');
+
+    return out;
   };
 });


### PR DESCRIPTION
The arktype case registered only `assertLoose`. This adds two more:

- **assertStrict** — `.onDeepUndeclaredKey('reject')`, checked with `.allows()`
- **parseStrict** — the same rejecting type called directly; arktype returns `type.errors` rather than throwing, so the case throws when the result is an `ArkErrors`

I left `parseSafe` out. arktype strips unknown keys with `.onDeepUndeclaredKey('delete')`, which clones the input and deletes from the clone. That clone copies the original's property descriptors, so cloning the frozen `validateData` fixture yields non-writable properties and the delete step throws `TypeError: Cannot assign to read only property 'deeplyNested'`. Every other assertion in that suite passes, including the nested one — only the frozen fixture breaks it.

Closes #1588
