### PR TITLE
feat: add ata-validator benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * [aeria](https://github.com/aeria-org/aeria)
 * [ajv](https://ajv.js.org/)
 * [ArkType](https://github.com/arktypeio/arktype)
+* [ata-validator](https://github.com/ata-core/ata-validator)
 * [banditypes](https://github.com/thoughtspile/banditypes)
 * [bueno](https://github.com/philipnilsson/bueno)
 * [caketype](https://github.com/justinyaodu/caketype)

--- a/cases/ata.ts
+++ b/cases/ata.ts
@@ -1,0 +1,64 @@
+import { Validator } from 'ata-validator';
+import { createCase } from '../benchmarks';
+
+const looseSchema = {
+  type: 'object',
+  properties: {
+    number: { type: 'number' },
+    negNumber: { type: 'number' },
+    maxNumber: { type: 'number' },
+    string: { type: 'string' },
+    longString: { type: 'string' },
+    boolean: { type: 'boolean' },
+    deeplyNested: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+        num: { type: 'number' },
+        bool: { type: 'boolean' },
+      },
+      required: ['foo', 'num', 'bool'],
+    },
+  },
+  required: [
+    'number',
+    'negNumber',
+    'maxNumber',
+    'string',
+    'longString',
+    'boolean',
+    'deeplyNested',
+  ],
+} as const;
+
+createCase('ata', 'assertLoose', () => {
+  const v = new Validator(looseSchema as never);
+
+  return data => {
+    const result = v.validate(data);
+
+    if (!result.valid) {
+      throw new Error(JSON.stringify(result.errors));
+    }
+
+    return true;
+  };
+});
+
+createCase('ata', 'assertStrict', () => {
+  const strictSchema = JSON.parse(JSON.stringify(looseSchema));
+  strictSchema.additionalProperties = false;
+  strictSchema.properties.deeplyNested.additionalProperties = false;
+
+  const v = new Validator(strictSchema);
+
+  return data => {
+    const result = v.validate(data);
+
+    if (!result.valid) {
+      throw new Error(JSON.stringify(result.errors));
+    }
+
+    return true;
+  };
+});

--- a/cases/index.ts
+++ b/cases/index.ts
@@ -2,6 +2,7 @@ export const cases = [
   'aeria',
   'ajv',
   'arktype',
+  'ata',
   'banditypes',
   'bueno',
   'caketype',

--- a/download-packages-popularity.ts
+++ b/download-packages-popularity.ts
@@ -15,6 +15,10 @@ export const packages = [
     packageName: 'arktype',
   },
   {
+    name: 'ata',
+    packageName: 'ata-validator',
+  },
+  {
     name: 'banditypes',
     packageName: 'banditypes',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/benchmark": "2.1.5",
         "ajv": "8.20.0",
         "arktype": "2.2.3",
+        "ata-validator": "1.10.0",
         "banditypes": "0.3.0",
         "benny": "3.7.1",
         "bueno": "0.1.5",
@@ -220,6 +221,109 @@
         "@arrows/error": "^1.0.2",
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/@ata-validator/native-darwin-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.10.0.tgz",
+      "integrity": "sha512-ji72AWqJnnTGjT1GFGTCBJIndclKWko+r4gdwzyuSsm5AR61hDYVQDmYxzmI1yXxKRGabKqlMsqXwH34OhMZ7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ata-validator/native-darwin-x64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.10.0.tgz",
+      "integrity": "sha512-0pICN5GGpHhuTvhHJRR9IgigSl30zbzsIuDBTjKWZKoyQGcPZY1VSS29hZSVmYmVWdPoEZvDDGYRFdqjq/TSEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ata-validator/native-linux-arm64-gnu": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.10.0.tgz",
+      "integrity": "sha512-n8oyif9KEUGLgWfCcaDiJNn8YnB4bNQsCpjr/fDA8bpD8HpgsfxkBAgtDKoAxQnQWZVuzgU++bcwRu04sDi2Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ata-validator/native-linux-arm64-musl": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.10.0.tgz",
+      "integrity": "sha512-mkSQgkJGdotzf41mSVMnhZ+p5ecPcUBqHGBlx+vIidtvN4pXR1bhUKFaxT8JUU2hVyQy3onHeQfiI5hS/Gnewg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ata-validator/native-linux-x64-gnu": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.10.0.tgz",
+      "integrity": "sha512-TGWjqqwtB1LPwl08SOmK0Z7VDLYF9he1ETYREYBEEwFCEwGd8XuFz/jgRGbk5mQC1NJDaqtLNtu+RLTmgqaRzg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ata-validator/native-linux-x64-musl": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.10.0.tgz",
+      "integrity": "sha512-05gTYrbKTIvKLgWjHLjZvlDCbSWoPZZhEmaFsgtsX4OdEASlCK+EmkVfwmD+oTvkvh6ASwvZ9bgpADwtgKCKvw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ata-validator/native-win32-x64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.10.0.tgz",
+      "integrity": "sha512-VQfGFGJBwrMRcpYk0u1y2KOQkaz3G8Hftw6eapUa7I7R6zdbZkWrNij93B+n9jVsQr48nVHzIlfI/PZq9pDoAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@babel/cli": {
       "version": "7.29.7",
@@ -3969,6 +4073,35 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ata-validator": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.10.0.tgz",
+      "integrity": "sha512-BhL2sUy1P9OCwzc6BKFOX4RbExz2h8cUS37vyaa5n3M8n8nC1zk5G6+0h2bp5UiPQNiKs5q7+vGr3G6HVx5Tyg==",
+      "license": "MIT",
+      "bin": {
+        "ata": "bin/ata.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@ata-validator/native-darwin-arm64": "1.10.0",
+        "@ata-validator/native-darwin-x64": "1.10.0",
+        "@ata-validator/native-linux-arm64-gnu": "1.10.0",
+        "@ata-validator/native-linux-arm64-musl": "1.10.0",
+        "@ata-validator/native-linux-x64-gnu": "1.10.0",
+        "@ata-validator/native-linux-x64-musl": "1.10.0",
+        "@ata-validator/native-win32-x64": "1.10.0"
+      },
+      "peerDependencies": {
+        "yaml": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/atob": {
@@ -10942,6 +11075,48 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "@ata-validator/native-darwin-arm64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.10.0.tgz",
+      "integrity": "sha512-ji72AWqJnnTGjT1GFGTCBJIndclKWko+r4gdwzyuSsm5AR61hDYVQDmYxzmI1yXxKRGabKqlMsqXwH34OhMZ7Q==",
+      "optional": true
+    },
+    "@ata-validator/native-darwin-x64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.10.0.tgz",
+      "integrity": "sha512-0pICN5GGpHhuTvhHJRR9IgigSl30zbzsIuDBTjKWZKoyQGcPZY1VSS29hZSVmYmVWdPoEZvDDGYRFdqjq/TSEw==",
+      "optional": true
+    },
+    "@ata-validator/native-linux-arm64-gnu": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.10.0.tgz",
+      "integrity": "sha512-n8oyif9KEUGLgWfCcaDiJNn8YnB4bNQsCpjr/fDA8bpD8HpgsfxkBAgtDKoAxQnQWZVuzgU++bcwRu04sDi2Vg==",
+      "optional": true
+    },
+    "@ata-validator/native-linux-arm64-musl": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.10.0.tgz",
+      "integrity": "sha512-mkSQgkJGdotzf41mSVMnhZ+p5ecPcUBqHGBlx+vIidtvN4pXR1bhUKFaxT8JUU2hVyQy3onHeQfiI5hS/Gnewg==",
+      "optional": true
+    },
+    "@ata-validator/native-linux-x64-gnu": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.10.0.tgz",
+      "integrity": "sha512-TGWjqqwtB1LPwl08SOmK0Z7VDLYF9he1ETYREYBEEwFCEwGd8XuFz/jgRGbk5mQC1NJDaqtLNtu+RLTmgqaRzg==",
+      "optional": true
+    },
+    "@ata-validator/native-linux-x64-musl": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.10.0.tgz",
+      "integrity": "sha512-05gTYrbKTIvKLgWjHLjZvlDCbSWoPZZhEmaFsgtsX4OdEASlCK+EmkVfwmD+oTvkvh6ASwvZ9bgpADwtgKCKvw==",
+      "optional": true
+    },
+    "@ata-validator/native-win32-x64": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.10.0.tgz",
+      "integrity": "sha512-VQfGFGJBwrMRcpYk0u1y2KOQkaz3G8Hftw6eapUa7I7R6zdbZkWrNij93B+n9jVsQr48nVHzIlfI/PZq9pDoAw==",
+      "optional": true
+    },
     "@babel/cli": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.29.7.tgz",
@@ -13419,6 +13594,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+    },
+    "ata-validator": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.10.0.tgz",
+      "integrity": "sha512-BhL2sUy1P9OCwzc6BKFOX4RbExz2h8cUS37vyaa5n3M8n8nC1zk5G6+0h2bp5UiPQNiKs5q7+vGr3G6HVx5Tyg==",
+      "requires": {
+        "@ata-validator/native-darwin-arm64": "1.10.0",
+        "@ata-validator/native-darwin-x64": "1.10.0",
+        "@ata-validator/native-linux-arm64-gnu": "1.10.0",
+        "@ata-validator/native-linux-arm64-musl": "1.10.0",
+        "@ata-validator/native-linux-x64-gnu": "1.10.0",
+        "@ata-validator/native-linux-x64-musl": "1.10.0",
+        "@ata-validator/native-win32-x64": "1.10.0"
+      }
     },
     "atob": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/benchmark": "2.1.5",
     "ajv": "8.20.0",
     "arktype": "2.2.3",
+    "ata-validator": "1.10.0",
     "banditypes": "0.3.0",
     "benny": "3.7.1",
     "bueno": "0.1.5",

--- a/test/benchmarks.test.ts
+++ b/test/benchmarks.test.ts
@@ -7,6 +7,7 @@ import { cases } from '../cases';
 import '../cases/aeria';
 import '../cases/ajv';
 import '../cases/arktype';
+import '../cases/ata';
 import '../cases/banditypes';
 import '../cases/bueno';
 import '../cases/caketype';


### PR DESCRIPTION
Adds ata-validator to the assertLoose and assertStrict suites, mirroring the ajv case: same draft-07 schema, throws on an invalid result.

ata-validator is a JSON Schema validator that compiles schemas to functions on first use, with an interpreter fallback where code generation is not available.

Verification:
- the four contract tests per suite pass for the new case (10 tests including the shared ones)
- ran the harness locally with `npm run start run ata` on Node 25, both suites complete

parseSafe and parseStrict are not included because the library validates rather than parses, same scope as the ajv entry.