### PR TITLE
docs: redesign the results UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,20 +7,13 @@
       name="description"
       content="Benchmark Comparison of Packages with Runtime Validation and TypeScript Support."
     />
-    <meta name="color-scheme" content="dark light" />
     <title>Runtype Benchmarks</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.min.css"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap"
     />
-    <style>
-      @media (prefers-color-scheme: dark) {
-        /* fix vega graph labels in dark mode */
-        svg .mark-text text {
-          fill: white;
-        }
-      }
-    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
     />
   </head>
   <body>

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -164,6 +164,23 @@ function getDenoMajorVersionNumber(denoVersion: string): number {
   return parseInt(match[1]);
 }
 
+// vega writes the datum description onto each bar as an aria-label; promoting
+// it to a <title> child gives the exact figure back on hover
+function withTooltips(svg: string) {
+  return svg.replace(
+    /<path([^>]*?aria-label="([^"]*?)"[^>]*?)\/>/g,
+    (match, attrs: string, label: string) =>
+      /ops\/sec|not implemented/.test(label)
+        ? `<path${attrs}><title>${label}</title></path>`
+        : match
+  );
+}
+
+const compactOps = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
 // vega sizes the name column and the value labels from the text itself, so the
 // plot can only fill the card exactly if we measure that text the same way
 const measureText = (() => {
@@ -236,7 +253,10 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
+      opsLabel: b.ops ? compactOps.format(b.ops) : 'n/a',
+      opsFull: b.ops
+        ? `${b.ops.toLocaleString('en-US')} ops/sec`
+        : 'not implemented',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and node-version
       benchmark: [
@@ -256,7 +276,10 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
+      opsLabel: b.ops ? compactOps.format(b.ops) : 'n/a',
+      opsFull: b.ops
+        ? `${b.ops.toLocaleString('en-US')} ops/sec`
+        : 'not implemented',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and bun-version
       benchmark: [
@@ -278,7 +301,10 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
+      opsLabel: b.ops ? compactOps.format(b.ops) : 'n/a',
+      opsFull: b.ops
+        ? `${b.ops.toLocaleString('en-US')} ops/sec`
+        : 'not implemented',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and deno-version
       benchmark: [
@@ -356,6 +382,7 @@ async function graph({
   const valueWidth = Math.max(
     ...allValues.map(v => measureText(v.opsLabel, `9.5px ${chart.monoFont}`))
   );
+  const maxOps = Math.max(...allValues.map(v => v.ops), 1);
   const versionWidth =
     versionCount > 1
       ? Math.max(
@@ -372,11 +399,16 @@ async function graph({
   );
 
   const estimatedPlotWidth = Math.max(
-    containerWidth - labelLimit - versionWidth - valueWidth - 22,
+    containerWidth - labelLimit - versionWidth - 22,
     160
   );
 
   const renderAt = async (plotWidth: number) => {
+    // the label of the longest bar would otherwise sit past the track's right
+    // edge, so end the scale beyond the data by exactly that label's width
+    const labelRoom = Math.min(valueWidth + 6, plotWidth * 0.4);
+    const domainMax = (maxOps * plotWidth) / Math.max(plotWidth - labelRoom, 1);
+
     const vegaSpec = vegaLite.compile({
       data: {
         values: [...valuesNodejs, ...valuesBun, ...valuesDeno],
@@ -438,6 +470,9 @@ async function graph({
               type: 'bar',
               cornerRadiusEnd: 2,
             },
+            encoding: {
+              description: { field: 'opsFull' },
+            },
           },
           {
             mark: {
@@ -459,12 +494,17 @@ async function graph({
             field: 'ops',
             type: 'quantitative',
             title: null,
+            scale: { domain: [0, domainMax], nice: true },
             axis: {
               orient: 'top',
               offset: 10,
               format: '~s',
               tickCount: 6,
               grid: false,
+              // keep tick labels inside the plot: flush the end ones, drop any
+              // that still would not fit
+              labelFlush: true,
+              labelBound: true,
               labelFontSize: 11,
               titleFontSize: 12.5,
               titleFontWeight: 'normal',
@@ -506,7 +546,10 @@ async function graph({
     });
     const svg = await view.toSVG();
 
-    return { svg, width: Number(/width="(\d+)"/.exec(svg)?.[1] ?? 0) };
+    return {
+      svg: withTooltips(svg),
+      width: Number(/width="(\d+)"/.exec(svg)?.[1] ?? 0),
+    };
   };
 
   // vega reserves room for the value label of the longest bar rather than the

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -175,6 +175,7 @@ async function graph({
   benchmarkResultsBun,
   benchmarkResultsDeno,
   sort,
+  dark,
 }: {
   selectedBenchmarks: typeof BENCHMARKS;
   selectedNodeJsVersions: string[];
@@ -184,6 +185,7 @@ async function graph({
   benchmarkResultsBun: BenchmarkResult[];
   benchmarkResultsDeno: BenchmarkResult[];
   sort?: 'alphabetically' | 'fastest' | 'popularity';
+  dark: boolean;
 }) {
   if (
     !selectedBenchmarks.length ||
@@ -193,6 +195,8 @@ async function graph({
   ) {
     return '';
   }
+
+  const chart = THEME.chart[dark ? 'dark' : 'light'];
 
   const selectedBenchmarkSet = new Set(selectedBenchmarks.map(b => b.name));
 
@@ -279,19 +283,19 @@ async function graph({
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < nodeJsVersionCount; i++) {
-      colorScaleRange.push(THEME.chart.series[b.name]);
+      colorScaleRange.push(chart.series[b.name]);
     }
   });
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < bunVersionCount; i++) {
-      colorScaleRange.push(THEME.chart.series[b.name]);
+      colorScaleRange.push(chart.series[b.name]);
     }
   });
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < denoVersionCount; i++) {
-      colorScaleRange.push(THEME.chart.series[b.name]);
+      colorScaleRange.push(chart.series[b.name]);
     }
   });
 
@@ -321,8 +325,6 @@ async function graph({
   const sortedNames: string[] = [];
 
   new Set(sortedValues.map(b => b.name)).forEach(n => sortedNames.push(n));
-
-  const chart = THEME.chart;
 
   const vegaSpec = vegaLite.compile({
     data: {
@@ -439,6 +441,7 @@ class Graph extends Component<
     valuesBun: BenchmarkResult[];
     valuesDeno: BenchmarkResult[];
     sort: Parameters<typeof graph>[0]['sort'];
+    dark: boolean;
   },
   { svg?: string }
 > {
@@ -460,6 +463,7 @@ class Graph extends Component<
         benchmarkResultsBun: this.props.valuesBun,
         benchmarkResultsDeno: this.props.valuesDeno,
         sort: this.props.sort,
+        dark: this.props.dark,
       }),
     });
   }
@@ -528,7 +532,7 @@ function BenchmarkDescription(props: {
       <h4>
         <span
           class="swatch"
-          style={{ background: THEME.chart.series[props.benchmark] }}
+          style={{ background: `var(--c-${props.benchmark})` }}
         />
         {props.name}
       </h4>
@@ -549,11 +553,15 @@ export class App extends Component<
     valuesDeno: BenchmarkResult[];
     sortBy: 'fastest' | 'alphabetically' | 'popularity';
     lastUpdated?: Date;
+    darkMode: boolean;
   }
 > {
+  darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
   constructor() {
     super();
     this.setState({
+      darkMode: this.darkModeQuery.matches,
       selectedBenchmarks: BENCHMARKS.reduce(
         (acc, b) => ({ ...acc, [b.name]: true }),
         {}
@@ -611,6 +619,10 @@ export class App extends Component<
   }
 
   async componentDidMount() {
+    this.darkModeQuery.addEventListener('change', event => {
+      this.setState({ darkMode: event.matches });
+    });
+
     loadPackagesPopularity().catch(err => {
       console.error(`error while loading package popularity`, err);
     });
@@ -881,6 +893,7 @@ export class App extends Component<
           valuesBun={this.state.valuesBun}
           valuesDeno={this.state.valuesDeno}
           sort={this.state.sortBy}
+          dark={this.state.darkMode}
           />
         </main>
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -164,6 +164,24 @@ function getDenoMajorVersionNumber(denoVersion: string): number {
   return parseInt(match[1]);
 }
 
+// vega sizes the name column and the value labels from the text itself, so the
+// plot can only fill the card exactly if we measure that text the same way
+const measureText = (() => {
+  let ctx: CanvasRenderingContext2D | undefined;
+
+  return (text: string, font: string) => {
+    ctx ??= document.createElement('canvas').getContext('2d') ?? undefined;
+
+    if (!ctx) {
+      return text.length * 7;
+    }
+
+    ctx.font = font;
+
+    return ctx.measureText(text).width;
+  };
+})();
+
 async function graph({
   selectedBenchmarks,
   selectedNodeJsVersions,
@@ -197,14 +215,6 @@ async function graph({
   }
 
   const chart = CHART[dark ? 'dark' : 'light'];
-
-  // the library-name column and the value labels are laid out by vega, so
-  // reserve room for both and give the bars whatever is left
-  const labelLimit = containerWidth < 560 ? 130 : 260;
-  const plotWidth = Math.min(
-    Math.max(containerWidth - labelLimit - 95, 240),
-    560
-  );
 
   const selectedBenchmarkSet = new Set(selectedBenchmarks.map(b => b.name));
 
@@ -337,134 +347,178 @@ async function graph({
 
   new Set(sortedValues.map(b => b.name)).forEach(n => sortedNames.push(n));
 
-  const vegaSpec = vegaLite.compile({
-    data: {
-      values: [...valuesNodejs, ...valuesBun, ...valuesDeno],
-    },
-    height: { step: 16 / versionCount },
-    spacing: 10,
-    background: 'transparent', // no white graphs for dark mode users
-    config: {
-      view: { stroke: null },
-      font: chart.font,
-      header: {
-        labelFont: chart.font,
-        labelColor: chart.headerColor,
-        labelFontWeight: 600,
+  // measure the two text columns vega puts either side of the bars, so the
+  // plot fills the card exactly: no dead gutter, no value label past the edge
+  const allValues = [...valuesNodejs, ...valuesBun, ...valuesDeno];
+  const nameWidth = Math.max(
+    ...sortedNames.map(n => measureText(n, `600 12.5px ${chart.font}`))
+  );
+  const valueWidth = Math.max(
+    ...allValues.map(v => measureText(v.opsLabel, `9.5px ${chart.monoFont}`))
+  );
+  const versionWidth =
+    versionCount > 1
+      ? Math.max(
+          ...allValues.map(v =>
+            measureText(v.benchmark.split('-')[3], `9px ${chart.monoFont}`)
+          )
+        ) + 8
+      : 0;
+
+  // a very long library name must not take the card over from the bars
+  const labelLimit = Math.max(
+    Math.min(nameWidth, containerWidth * 0.3, 240),
+    90
+  );
+
+  const estimatedPlotWidth = Math.max(
+    containerWidth - labelLimit - versionWidth - valueWidth - 22,
+    160
+  );
+
+  const renderAt = async (plotWidth: number) => {
+    const vegaSpec = vegaLite.compile({
+      data: {
+        values: [...valuesNodejs, ...valuesBun, ...valuesDeno],
       },
-      axis: {
-        labelFont: chart.monoFont,
-        labelColor: chart.axisColor,
-        titleFont: chart.font,
-        titleColor: chart.axisColor,
-        gridColor: chart.gridColor,
-        tickColor: chart.domainColor,
-        domainColor: chart.domainColor,
-      },
-    },
-    facet: {
-      row: {
-        field: 'name',
-        title: null,
+      height: { step: 16 / versionCount },
+      spacing: 10,
+      background: 'transparent', // no white graphs for dark mode users
+      config: {
+        view: { stroke: null },
+        font: chart.font,
         header: {
-          labelAngle: 0,
-          labelOrient: 'left',
-          labelAnchor: 'middle',
-          labelAlign: 'left',
-          labelFontSize: 12.5,
-          labelLimit,
+          labelFont: chart.font,
+          labelColor: chart.headerColor,
+          labelFontWeight: 600,
         },
-        sort: sortedNames,
+        axis: {
+          labelFont: chart.monoFont,
+          labelColor: chart.axisColor,
+          titleFont: chart.font,
+          titleColor: chart.axisColor,
+          gridColor: chart.gridColor,
+          tickColor: chart.domainColor,
+          domainColor: chart.domainColor,
+        },
       },
-    },
-    spec: {
-      layer: [
-        {
-          // full-width track so benchmarks a library doesn't run still
-          // read as deliberate empty rows
-          mark: {
-            type: 'bar',
-            cornerRadius: 2,
-          },
-          width: plotWidth,
-          encoding: {
-            x: { value: 0 },
-            x2: { value: plotWidth },
-            color: { value: chart.trackColor },
-          },
-        },
-        {
-          mark: {
-            type: 'bar',
-            cornerRadiusEnd: 2,
-          },
-        },
-        {
-          mark: {
-            type: 'text',
-            align: 'left',
-            baseline: 'middle',
-            dx: 4,
-            font: chart.monoFont,
-            fontSize: 9.5,
-            fill: chart.valueColor,
-          },
-          encoding: {
-            text: { field: 'opsLabel' },
-          },
-        },
-      ],
-      encoding: {
-        x: {
-          field: 'ops',
-          type: 'quantitative',
-          title: ['operations / sec', '(better ▶)'],
-          axis: {
-            orient: 'top',
-            offset: 10,
-            format: '~s',
-            tickCount: 6,
-            grid: false,
-            labelFontSize: 11,
-            titleFontSize: 12.5,
-            titleFontWeight: 'normal',
-          },
-        },
-        y: {
-          field: 'benchmark',
-          type: 'nominal',
+      facet: {
+        row: {
+          field: 'name',
           title: null,
-          // one runtime version needs no label; several would otherwise be
-          // indistinguishable repeats of the same color
-          axis:
-            versionCount > 1
-              ? {
-                  labelExpr: "split(datum.label, '-')[3]",
-                  labelFont: chart.monoFont,
-                  labelFontSize: 9,
-                  labelColor: chart.axisColor,
-                  labelPadding: 4,
-                  domain: false,
-                  ticks: false,
-                }
-              : null,
+          header: {
+            labelAngle: 0,
+            labelOrient: 'left',
+            labelAnchor: 'middle',
+            labelAlign: 'left',
+            labelFontSize: 12.5,
+            labelLimit,
+          },
+          sort: sortedNames,
         },
-        color: {
-          field: 'benchmark',
-          type: 'nominal',
-          legend: null,
-          scale: {
-            range: colorScaleRange,
+      },
+      spec: {
+        layer: [
+          {
+            // full-width track so benchmarks a library doesn't run still
+            // read as deliberate empty rows
+            mark: {
+              type: 'bar',
+              cornerRadius: 2,
+            },
+            width: plotWidth,
+            encoding: {
+              x: { value: 0 },
+              x2: { value: plotWidth },
+              color: { value: chart.trackColor },
+            },
+          },
+          {
+            mark: {
+              type: 'bar',
+              cornerRadiusEnd: 2,
+            },
+          },
+          {
+            mark: {
+              type: 'text',
+              align: 'left',
+              baseline: 'middle',
+              dx: 4,
+              font: chart.monoFont,
+              fontSize: 9.5,
+              fill: chart.valueColor,
+            },
+            encoding: {
+              text: { field: 'opsLabel' },
+            },
+          },
+        ],
+        encoding: {
+          x: {
+            field: 'ops',
+            type: 'quantitative',
+            title: null,
+            axis: {
+              orient: 'top',
+              offset: 10,
+              format: '~s',
+              tickCount: 6,
+              grid: false,
+              labelFontSize: 11,
+              titleFontSize: 12.5,
+              titleFontWeight: 'normal',
+            },
+          },
+          y: {
+            field: 'benchmark',
+            type: 'nominal',
+            title: null,
+            // one runtime version needs no label; several would otherwise be
+            // indistinguishable repeats of the same color
+            axis:
+              versionCount > 1
+                ? {
+                    labelExpr: "split(datum.label, '-')[3]",
+                    labelFont: chart.monoFont,
+                    labelFontSize: 9,
+                    labelColor: chart.axisColor,
+                    labelPadding: 4,
+                    domain: false,
+                    ticks: false,
+                  }
+                : null,
+          },
+          color: {
+            field: 'benchmark',
+            type: 'nominal',
+            legend: null,
+            scale: {
+              range: colorScaleRange,
+            },
           },
         },
       },
-    },
-  });
+    });
 
-  const view = new vega.View(vega.parse(vegaSpec.spec), { renderer: 'none' });
-  const svg = await view.toSVG();
+    const view = new vega.View(vega.parse(vegaSpec.spec), {
+      renderer: 'none',
+    });
+    const svg = await view.toSVG();
 
-  return svg;
+    return { svg, width: Number(/width="(\d+)"/.exec(svg)?.[1] ?? 0) };
+  };
+
+  // vega reserves room for the value label of the longest bar rather than the
+  // widest one, so the first render lands short of the card; correct it once
+  const first = await renderAt(estimatedPlotWidth);
+  const delta = containerWidth - first.width;
+
+  if (Math.abs(delta) <= 2) {
+    return first.svg;
+  }
+
+  return (await renderAt(Math.max(estimatedPlotWidth + delta, 160))).svg;
 }
 
 class Graph extends Component<
@@ -806,127 +860,132 @@ export class App extends Component<
           </div>
         </header>
 
-        <section class="controls">
-          <fieldset class="control-group">
-            <legend>Benchmarks</legend>
-            <div class="chip-row">
-              {BENCHMARKS.map(b => {
-                return (
-                  <Chip
-                    id={b.name}
-                    color={`var(--c-${b.name})`}
-                    checked={this.state.selectedBenchmarks[b.name] ?? false}
-                    label={b.label}
-                    onChange={checked =>
-                      this.setState(state => ({
-                        ...state,
-                        selectedBenchmarks: {
-                          ...this.state.selectedBenchmarks,
-                          [b.name]: checked,
-                        },
-                      }))
-                    }
-                  />
-                );
-              })}
-            </div>
-          </fieldset>
+        <div class="controls-col">
+          <section class="controls">
+            <fieldset class="control-group">
+              <legend>Benchmarks</legend>
+              <div class="chip-row">
+                {BENCHMARKS.map(b => {
+                  return (
+                    <Chip
+                      id={b.name}
+                      color={`var(--c-${b.name})`}
+                      checked={this.state.selectedBenchmarks[b.name] ?? false}
+                      label={b.label}
+                      onChange={checked =>
+                        this.setState(state => ({
+                          ...state,
+                          selectedBenchmarks: {
+                            ...this.state.selectedBenchmarks,
+                            [b.name]: checked,
+                          },
+                        }))
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </fieldset>
 
-          <fieldset class="control-group">
-            <legend>Node.js</legend>
-            <div class="chip-row">
-              {this.getNodeJsVersions().map(v => {
-                return (
-                  <Chip
-                    id={v}
-                    checked={this.state.selectedNodeJsVersions[v] ?? false}
-                    label={v}
-                    onChange={checked =>
-                      this.setState(state => ({
-                        ...state,
-                        selectedNodeJsVersions: {
-                          ...this.state.selectedNodeJsVersions,
-                          [v]: checked,
-                        },
-                      }))
-                    }
-                  />
-                );
-              })}
-            </div>
-          </fieldset>
+            <fieldset class="control-group">
+              <legend>Node.js</legend>
+              <div class="chip-row">
+                {this.getNodeJsVersions().map(v => {
+                  return (
+                    <Chip
+                      id={v}
+                      checked={this.state.selectedNodeJsVersions[v] ?? false}
+                      label={v}
+                      onChange={checked =>
+                        this.setState(state => ({
+                          ...state,
+                          selectedNodeJsVersions: {
+                            ...this.state.selectedNodeJsVersions,
+                            [v]: checked,
+                          },
+                        }))
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </fieldset>
 
-          <fieldset class="control-group">
-            <legend>Bun</legend>
-            <div class="chip-row">
-              {this.getBunVersions().map(v => {
-                return (
-                  <Chip
-                    id={v}
-                    checked={this.state.selectedBunVersions[v] ?? false}
-                    label={v}
-                    onChange={checked =>
-                      this.setState(state => ({
-                        ...state,
-                        selectedBunVersions: {
-                          ...this.state.selectedBunVersions,
-                          [v]: checked,
-                        },
-                      }))
-                    }
-                  />
-                );
-              })}
-            </div>
-          </fieldset>
+            <fieldset class="control-group">
+              <legend>Bun</legend>
+              <div class="chip-row">
+                {this.getBunVersions().map(v => {
+                  return (
+                    <Chip
+                      id={v}
+                      checked={this.state.selectedBunVersions[v] ?? false}
+                      label={v}
+                      onChange={checked =>
+                        this.setState(state => ({
+                          ...state,
+                          selectedBunVersions: {
+                            ...this.state.selectedBunVersions,
+                            [v]: checked,
+                          },
+                        }))
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </fieldset>
 
-          <fieldset class="control-group">
-            <legend>Deno</legend>
-            <div class="chip-row">
-              {this.getDenoVersions().map(v => {
-                return (
-                  <Chip
-                    id={v}
-                    checked={this.state.selectedDenoVersions[v] ?? false}
-                    label={v}
-                    onChange={checked =>
-                      this.setState(state => ({
-                        ...state,
-                        selectedDenoVersions: {
-                          ...this.state.selectedDenoVersions,
-                          [v]: checked,
-                        },
-                      }))
-                    }
-                  />
-                );
-              })}
-            </div>
-          </fieldset>
+            <fieldset class="control-group">
+              <legend>Deno</legend>
+              <div class="chip-row">
+                {this.getDenoVersions().map(v => {
+                  return (
+                    <Chip
+                      id={v}
+                      checked={this.state.selectedDenoVersions[v] ?? false}
+                      label={v}
+                      onChange={checked =>
+                        this.setState(state => ({
+                          ...state,
+                          selectedDenoVersions: {
+                            ...this.state.selectedDenoVersions,
+                            [v]: checked,
+                          },
+                        }))
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </fieldset>
 
-          <div class="control-group">
-            <span class="group-label" id="sort-label">
-              Sort
-            </span>
-            <select
-              class="sort-select"
-              aria-labelledby="sort-label"
-              onChange={
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (event: any) => {
-                  this.setState({ sortBy: event.target.value });
+            <div class="control-group">
+              <span class="group-label" id="sort-label">
+                Sort
+              </span>
+              <select
+                class="sort-select"
+                aria-labelledby="sort-label"
+                onChange={
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (event: any) => {
+                    this.setState({ sortBy: event.target.value });
+                  }
                 }
-              }
-              value={this.state.sortBy}
-            >
-              <option value="fastest">Fastest</option>
-              <option value="alphabetically">Alphabetically</option>
-              <option value="popularity">Popularity</option>
-            </select>
-          </div>
-        </section>
+                value={this.state.sortBy}
+              >
+                <option value="fastest">Fastest</option>
+                <option value="alphabetically">Alphabetically</option>
+                <option value="popularity">Popularity</option>
+              </select>
+            </div>
+          </section>
+        </div>
 
         <main class="chart" ref={this.chartRef}>
+          <p class="chart-caption">
+            operations / sec <span>— higher is better</span>
+          </p>
           <Graph
             benchmarks={BENCHMARKS.filter(
               b => this.state.selectedBenchmarks[b.name]

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,9 +1,7 @@
 import { Component, type ComponentChildren } from 'preact';
 import * as vega from 'vega';
 import * as vegaLite from 'vega-lite';
-import { activeTheme } from './theme.js';
-
-const THEME = activeTheme();
+import { CHART } from './theme.js';
 
 // which results are attempted to load
 // the first is selected automatically
@@ -196,7 +194,7 @@ async function graph({
     return '';
   }
 
-  const chart = THEME.chart[dark ? 'dark' : 'light'];
+  const chart = CHART[dark ? 'dark' : 'light'];
 
   const selectedBenchmarkSet = new Set(selectedBenchmarks.map(b => b.name));
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,6 +1,9 @@
 import { Component, type ComponentChildren } from 'preact';
 import * as vega from 'vega';
 import * as vegaLite from 'vega-lite';
+import { activeTheme } from './theme.js';
+
+const THEME = activeTheme();
 
 // which results are attempted to load
 // the first is selected automatically
@@ -22,43 +25,12 @@ interface BenchmarkResult {
   margin: number;
 }
 
-// colors taken from https://colorbrewer2.org/?type=qualitative&scheme=Set3&n=12
-const COLORS = [
-  '#8dd3c7',
-  // '#ffffb3', not this one .. looks too bright to me
-  '#bebada',
-  '#fb8072',
-  '#80b1d3',
-  '#fdb462',
-  '#b3de69',
-  '#fccde5',
-  '#d9d9d9',
-  '#bc80bd',
-  '#ccebc5',
-  '#ffed6f',
-];
-
-// create a stable color list
+// colors come from the active theme, keyed by benchmark name
 const BENCHMARKS = [
-  { name: 'parseSafe', label: 'Safe Parsing', color: COLORS[0], order: '0' },
-  {
-    name: 'parseStrict',
-    label: 'Strict Parsing',
-    color: COLORS[1],
-    order: '1',
-  },
-  {
-    name: 'assertLoose',
-    label: 'Loose Assertion',
-    color: COLORS[2],
-    order: '2',
-  },
-  {
-    name: 'assertStrict',
-    label: 'Strict Assertion',
-    color: COLORS[3],
-    order: '3',
-  },
+  { name: 'parseSafe', label: 'Safe Parsing', order: '0' },
+  { name: 'parseStrict', label: 'Strict Parsing', order: '1' },
+  { name: 'assertLoose', label: 'Loose Assertion', order: '2' },
+  { name: 'assertStrict', label: 'Strict Assertion', order: '3' },
 ];
 
 // order lookup table
@@ -242,7 +214,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops.toLocaleString('en-US'),
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and node-version
       benchmark: [
@@ -262,7 +234,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops.toLocaleString('en-US'),
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and bun-version
       benchmark: [
@@ -284,7 +256,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops.toLocaleString('en-US'),
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and deno-version
       benchmark: [
@@ -307,19 +279,19 @@ async function graph({
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < nodeJsVersionCount; i++) {
-      colorScaleRange.push(b.color);
+      colorScaleRange.push(THEME.chart.series[b.name]);
     }
   });
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < bunVersionCount; i++) {
-      colorScaleRange.push(b.color);
+      colorScaleRange.push(THEME.chart.series[b.name]);
     }
   });
 
   selectedBenchmarks.forEach(b => {
     for (let i = 0; i < denoVersionCount; i++) {
-      colorScaleRange.push(b.color);
+      colorScaleRange.push(THEME.chart.series[b.name]);
     }
   });
 
@@ -350,14 +322,35 @@ async function graph({
 
   new Set(sortedValues.map(b => b.name)).forEach(n => sortedNames.push(n));
 
+  const chart = THEME.chart;
+
   const vegaSpec = vegaLite.compile({
     data: {
       values: [...valuesNodejs, ...valuesBun, ...valuesDeno],
     },
     height: {
-      step: 15 / (nodeJsVersionCount + bunVersionCount + denoVersionCount),
+      step: 16 / (nodeJsVersionCount + bunVersionCount + denoVersionCount),
     },
+    spacing: 10,
     background: 'transparent', // no white graphs for dark mode users
+    config: {
+      view: { stroke: null },
+      font: chart.font,
+      header: {
+        labelFont: chart.font,
+        labelColor: chart.headerColor,
+        labelFontWeight: 600,
+      },
+      axis: {
+        labelFont: chart.monoFont,
+        labelColor: chart.axisColor,
+        titleFont: chart.font,
+        titleColor: chart.axisColor,
+        gridColor: chart.gridColor,
+        tickColor: chart.domainColor,
+        domainColor: chart.domainColor,
+      },
+    },
     facet: {
       row: {
         field: 'name',
@@ -367,7 +360,8 @@ async function graph({
           labelOrient: 'left',
           labelAnchor: 'middle',
           labelAlign: 'left',
-          labelFontSize: 12,
+          labelFontSize: 12.5,
+          labelLimit: 260,
         },
         sort: sortedNames,
       },
@@ -375,15 +369,21 @@ async function graph({
     spec: {
       layer: [
         {
-          mark: 'bar',
-          width: 600,
+          mark: {
+            type: 'bar',
+            cornerRadiusEnd: 2,
+          },
+          width: chart.width,
         },
         {
           mark: {
             type: 'text',
             align: 'left',
             baseline: 'middle',
-            dx: 3,
+            dx: 4,
+            font: chart.monoFont,
+            fontSize: 9.5,
+            fill: chart.valueColor,
           },
           encoding: {
             text: { field: 'opsLabel' },
@@ -398,8 +398,10 @@ async function graph({
           axis: {
             orient: 'top',
             offset: 10,
-            labelFontSize: 12,
-            titleFontSize: 14,
+            format: '~s',
+            tickCount: 6,
+            labelFontSize: 11,
+            titleFontSize: 12.5,
             titleFontWeight: 'normal',
           },
         },
@@ -468,23 +470,14 @@ class Graph extends Component<
     });
 
     if (!this.state.svg) {
-      return (
-        <div style={{ margin: '5rem' }}>
-          <i>No Benchmark Selected</i>
-        </div>
-      );
+      return <div class="empty">No Benchmark Selected</div>;
     }
 
-    return (
-      <div
-        style={{ marginBottom: '1rem' }}
-        dangerouslySetInnerHTML={{ __html: this.state.svg }}
-      />
-    );
+    return <div dangerouslySetInnerHTML={{ __html: this.state.svg }} />;
   }
 }
 
-function Checkbox(props: {
+function Chip(props: {
   id: string;
   label: string;
   color?: string;
@@ -492,12 +485,9 @@ function Checkbox(props: {
   onChange: (checked: boolean) => void;
 }) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        backgroundColor: props.color,
-        color: props.color ? 'black' : undefined,
-      }}
+    <label
+      class={`chip${props.checked ? ' checked' : ''}`}
+      style={props.color ? { '--dot': props.color } : undefined}
     >
       <input
         id={props.id}
@@ -506,32 +496,41 @@ function Checkbox(props: {
         checked={props.checked}
         onInput={() => props.onChange(!props.checked)}
       />
-      <label style={{ width: '100%' }} for={props.id}>
-        {props.label}
-      </label>
-    </div>
+      {props.color && <span class="dot" />}
+      {props.label}
+    </label>
+  );
+}
+
+function StarIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+    </svg>
+  );
+}
+
+function ForkIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+    </svg>
   );
 }
 
 function BenchmarkDescription(props: {
   name: string;
-  color: string | undefined;
+  benchmark: string;
   children?: ComponentChildren;
 }) {
   return (
-    <div style={{ marginBotton: '1rem' }}>
+    <div class="bench-doc">
       <h4>
         <span
-          style={{
-            backgroundColor: props.color ?? 'pink',
-            display: 'inline-block',
-            width: '2rem',
-            marginRight: '0.5rem',
-          }}
-        >
-          &nbsp;
-        </span>
-        {props.name}{' '}
+          class="swatch"
+          style={{ background: THEME.chart.series[props.benchmark] }}
+        />
+        {props.name}
       </h4>
       {props.children}
     </div>
@@ -699,65 +698,57 @@ export class App extends Component<
 
   render() {
     return (
-      <div>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'baseline',
-            justifyContent: 'space-between',
-          }}
-        >
-          <h1>Runtype Benchmarks</h1>
+      <div class="app">
+        <header class="masthead">
           <div>
+            <h1>Runtype Benchmarks</h1>
+            <div class="strip" aria-hidden="true">
+              {BENCHMARKS.map(b => (
+                <span style={{ background: `var(--c-${b.name})` }} />
+              ))}
+            </div>
+            <p class="tagline">
+              Benchmark comparison of packages with runtime validation and
+              TypeScript support.
+            </p>
+            {this.state.lastUpdated && (
+              <p class="updated">
+                Data last updated:{' '}
+                {this.state.lastUpdated.toLocaleDateString(undefined, {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+            )}
+          </div>
+          <div class="gh-links">
             <a
-              class="github-button"
+              class="gh-btn"
               href="https://github.com/moltar/typescript-runtime-type-benchmarks"
-              data-color-scheme="no-preference: dark; light: dark_dimmed; dark: dark;"
-              data-icon="octicon-star"
-              data-size="large"
-              data-show-count="true"
               aria-label="Star moltar/typescript-runtime-type-benchmarks on GitHub"
             >
-              Star
+              <StarIcon /> Star
             </a>
             <a
-              class="github-button"
+              class="gh-btn"
               href="https://github.com/moltar/typescript-runtime-type-benchmarks/fork"
-              data-color-scheme="no-preference: dark; light: dark_dimmed; dark: dark;"
-              data-icon="octicon-repo-forked"
-              data-size="large"
-              data-show-count="true"
               aria-label="Fork moltar/typescript-runtime-type-benchmarks on GitHub"
             >
-              Fork
+              <ForkIcon /> Fork
             </a>
           </div>
-        </div>
-        <p>
-          Benchmark Comparison of Packages with Runtime Validation and
-          TypeScript Support
-        </p>
+        </header>
 
-        {this.state.lastUpdated && (
-          <p style={{ color: '#666', fontSize: '0.9rem', marginTop: '-0.5rem' }}>
-            Data last updated:{' '}
-            {this.state.lastUpdated.toLocaleDateString(undefined, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </p>
-        )}
-
-        <div style={{ display: 'flex', margin: '1rem 0' }}>
-          <div style={{ width: '12rem', marginRight: '1rem' }}>
-            <label>Benchmarks:</label>
-            <div>
+        <section class="controls">
+          <fieldset class="control-group">
+            <legend>Benchmarks</legend>
+            <div class="chip-row">
               {BENCHMARKS.map(b => {
                 return (
-                  <Checkbox
+                  <Chip
                     id={b.name}
-                    color={b.color}
+                    color={`var(--c-${b.name})`}
                     checked={this.state.selectedBenchmarks[b.name] ?? false}
                     label={b.label}
                     onChange={checked =>
@@ -773,14 +764,14 @@ export class App extends Component<
                 );
               })}
             </div>
-          </div>
+          </fieldset>
 
-          <div style={{ width: '12rem' }}>
-            <label>Node.js Versions:</label>
-            <div>
+          <fieldset class="control-group">
+            <legend>Node.js</legend>
+            <div class="chip-row">
               {this.getNodeJsVersions().map(v => {
                 return (
-                  <Checkbox
+                  <Chip
                     id={v}
                     checked={this.state.selectedNodeJsVersions[v] ?? false}
                     label={v}
@@ -797,14 +788,14 @@ export class App extends Component<
                 );
               })}
             </div>
-          </div>
+          </fieldset>
 
-          <div style={{ width: '12rem' }}>
-            <label>Bun Versions:</label>
-            <div>
+          <fieldset class="control-group">
+            <legend>Bun</legend>
+            <div class="chip-row">
               {this.getBunVersions().map(v => {
                 return (
-                  <Checkbox
+                  <Chip
                     id={v}
                     checked={this.state.selectedBunVersions[v] ?? false}
                     label={v}
@@ -821,14 +812,14 @@ export class App extends Component<
                 );
               })}
             </div>
-          </div>
+          </fieldset>
 
-          <div style={{ width: '12rem' }}>
-            <label>Deno Versions:</label>
-            <div>
+          <fieldset class="control-group">
+            <legend>Deno</legend>
+            <div class="chip-row">
               {this.getDenoVersions().map(v => {
                 return (
-                  <Checkbox
+                  <Chip
                     id={v}
                     checked={this.state.selectedDenoVersions[v] ?? false}
                     label={v}
@@ -845,29 +836,32 @@ export class App extends Component<
                 );
               })}
             </div>
-          </div>
+          </fieldset>
 
-          <div style={{ width: '12rem' }}>
-            <label>
-              Sort:
-              <select
-                onChange={
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  (event: any) => {
-                    this.setState({ sortBy: event.target.value });
-                  }
+          <div class="control-group">
+            <span class="group-label" id="sort-label">
+              Sort
+            </span>
+            <select
+              class="sort-select"
+              aria-labelledby="sort-label"
+              onChange={
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (event: any) => {
+                  this.setState({ sortBy: event.target.value });
                 }
-                value={this.state.sortBy}
-              >
-                <option value="fastest">Fastest</option>
-                <option value="alphabetically">Alphabetically</option>
-                <option value="popularity">Popularity</option>
-              </select>
-            </label>
+              }
+              value={this.state.sortBy}
+            >
+              <option value="fastest">Fastest</option>
+              <option value="alphabetically">Alphabetically</option>
+              <option value="popularity">Popularity</option>
+            </select>
           </div>
-        </div>
+        </section>
 
-        <Graph
+        <main class="chart">
+          <Graph
           benchmarks={BENCHMARKS.filter(
             b => this.state.selectedBenchmarks[b.name]
           )}
@@ -887,57 +881,45 @@ export class App extends Component<
           valuesBun={this.state.valuesBun}
           valuesDeno={this.state.valuesDeno}
           sort={this.state.sortBy}
-        />
+          />
+        </main>
 
-        <div>
-          <BenchmarkDescription
-            name="Safe Parsing"
-            color={BENCHMARKS.find(x => x.name === 'parseSafe')?.color}
-          >
+        <section class="bench-docs">
+          <BenchmarkDescription name="Safe Parsing" benchmark="parseSafe">
             <p>
-              Check the input object against a schema and return it.
-              <br />
-              Raise an error if the input object does not conform to the schema,
-              e.g. an attribute is a number instead of a string or an attribute
-              is missing completely.
-              <br />
-              Any extra keys in the input object that are not defined in the
-              schema must be removed.
+              Check the input object against a schema and return it. Raise an
+              error if the input object does not conform to the schema, e.g. an
+              attribute is a number instead of a string or an attribute is
+              missing completely. Any extra keys in the input object that are
+              not defined in the schema must be removed.
             </p>
           </BenchmarkDescription>
 
-          <BenchmarkDescription
-            name="Strict Parsing"
-            color={BENCHMARKS.find(x => x.name === 'parseStrict')?.color}
-          >
+          <BenchmarkDescription name="Strict Parsing" benchmark="parseStrict">
             <p>
               Like safe parsing but raise an error if input objects contain
               extra keys.
             </p>
           </BenchmarkDescription>
 
-          <BenchmarkDescription
-            name="Loose Assertion"
-            color={BENCHMARKS.find(x => x.name === 'assertLoose')?.color}
-          >
+          <BenchmarkDescription name="Loose Assertion" benchmark="assertLoose">
             <p>
               Check the input object against a schema and raise an exception if
-              it does not match.
-              <br />
-              No errors are raised when encountering extra keys.
+              it does not match. No errors are raised when encountering extra
+              keys.
             </p>
           </BenchmarkDescription>
 
           <BenchmarkDescription
             name="Strict Assertion"
-            color={BENCHMARKS.find(x => x.name === 'assertStrict')?.color}
+            benchmark="assertStrict"
           >
             <p>
               Like loose assertion but raise an error if input objects or nested
               input objects contain extra keys.
             </p>
           </BenchmarkDescription>
-        </div>
+        </section>
       </div>
     );
   }

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, type ComponentChildren } from 'preact';
+import { Component, type ComponentChildren, createRef } from 'preact';
 import * as vega from 'vega';
 import * as vegaLite from 'vega-lite';
 import { CHART } from './theme.js';
@@ -174,6 +174,7 @@ async function graph({
   benchmarkResultsDeno,
   sort,
   dark,
+  containerWidth,
 }: {
   selectedBenchmarks: typeof BENCHMARKS;
   selectedNodeJsVersions: string[];
@@ -184,6 +185,7 @@ async function graph({
   benchmarkResultsDeno: BenchmarkResult[];
   sort?: 'alphabetically' | 'fastest' | 'popularity';
   dark: boolean;
+  containerWidth: number;
 }) {
   if (
     !selectedBenchmarks.length ||
@@ -195,6 +197,14 @@ async function graph({
   }
 
   const chart = CHART[dark ? 'dark' : 'light'];
+
+  // the library-name column and the value labels are laid out by vega, so
+  // reserve room for both and give the bars whatever is left
+  const labelLimit = containerWidth < 560 ? 130 : 260;
+  const plotWidth = Math.min(
+    Math.max(containerWidth - labelLimit - 95, 240),
+    560
+  );
 
   const selectedBenchmarkSet = new Set(selectedBenchmarks.map(b => b.name));
 
@@ -275,6 +285,9 @@ async function graph({
   const bunVersionCount = new Set(valuesBun.map(v => v.runtimeVersion)).size;
   const denoVersionCount = new Set(valuesDeno.map(v => v.runtimeVersion)).size;
 
+  const versionCount =
+    nodeJsVersionCount + bunVersionCount + denoVersionCount;
+
   // build a color map so that each benchmark has the same color in different
   // node-versions
   const colorScaleRange: string[] = [];
@@ -328,9 +341,7 @@ async function graph({
     data: {
       values: [...valuesNodejs, ...valuesBun, ...valuesDeno],
     },
-    height: {
-      step: 16 / (nodeJsVersionCount + bunVersionCount + denoVersionCount),
-    },
+    height: { step: 16 / versionCount },
     spacing: 10,
     background: 'transparent', // no white graphs for dark mode users
     config: {
@@ -361,7 +372,7 @@ async function graph({
           labelAnchor: 'middle',
           labelAlign: 'left',
           labelFontSize: 12.5,
-          labelLimit: 260,
+          labelLimit,
         },
         sort: sortedNames,
       },
@@ -375,10 +386,10 @@ async function graph({
             type: 'bar',
             cornerRadius: 2,
           },
-          width: chart.width,
+          width: plotWidth,
           encoding: {
             x: { value: 0 },
-            x2: { value: chart.width },
+            x2: { value: plotWidth },
             color: { value: chart.trackColor },
           },
         },
@@ -422,8 +433,21 @@ async function graph({
         y: {
           field: 'benchmark',
           type: 'nominal',
-          title: 'Benchmark',
-          axis: null, // to debug the bars: axis: {labelFontSize: 3},
+          title: null,
+          // one runtime version needs no label; several would otherwise be
+          // indistinguishable repeats of the same color
+          axis:
+            versionCount > 1
+              ? {
+                  labelExpr: "split(datum.label, '-')[3]",
+                  labelFont: chart.monoFont,
+                  labelFontSize: 9,
+                  labelColor: chart.axisColor,
+                  labelPadding: 4,
+                  domain: false,
+                  ticks: false,
+                }
+              : null,
         },
         color: {
           field: 'benchmark',
@@ -454,6 +478,7 @@ class Graph extends Component<
     valuesDeno: BenchmarkResult[];
     sort: Parameters<typeof graph>[0]['sort'];
     dark: boolean;
+    containerWidth: number;
   },
   { svg?: string }
 > {
@@ -476,6 +501,7 @@ class Graph extends Component<
         benchmarkResultsDeno: this.props.valuesDeno,
         sort: this.props.sort,
         dark: this.props.dark,
+        containerWidth: this.props.containerWidth,
       }),
     });
   }
@@ -566,9 +592,12 @@ export class App extends Component<
     sortBy: 'fastest' | 'alphabetically' | 'popularity';
     lastUpdated?: Date;
     darkMode: boolean;
+    chartWidth: number;
   }
 > {
   darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  chartRef = createRef<HTMLElement>();
+  resizeObserver?: ResizeObserver;
 
   constructor() {
     super();
@@ -585,6 +614,7 @@ export class App extends Component<
       valuesBun: [],
       valuesDeno: [],
       sortBy: 'fastest' as const,
+      chartWidth: 560,
     };
   }
 
@@ -634,6 +664,14 @@ export class App extends Component<
     this.darkModeQuery.addEventListener('change', event => {
       this.setState({ darkMode: event.matches });
     });
+
+    // the chart is a static svg, so it has to be re-rendered at the new size
+    if (this.chartRef.current) {
+      this.resizeObserver = new ResizeObserver(([entry]) => {
+        this.setState({ chartWidth: entry.contentRect.width });
+      });
+      this.resizeObserver.observe(this.chartRef.current);
+    }
 
     loadPackagesPopularity().catch(err => {
       console.error(`error while loading package popularity`, err);
@@ -718,6 +756,10 @@ export class App extends Component<
           console.info(`no data for deno ${v}`, err);
         });
     });
+  }
+
+  componentWillUnmount() {
+    this.resizeObserver?.disconnect();
   }
 
   render() {
@@ -884,7 +926,7 @@ export class App extends Component<
           </div>
         </section>
 
-        <main class="chart">
+        <main class="chart" ref={this.chartRef}>
           <Graph
             benchmarks={BENCHMARKS.filter(
               b => this.state.selectedBenchmarks[b.name]
@@ -906,6 +948,7 @@ export class App extends Component<
             valuesDeno={this.state.valuesDeno}
             sort={this.state.sortBy}
             dark={this.state.darkMode}
+            containerWidth={this.state.chartWidth}
           />
         </main>
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -216,7 +216,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and node-version
       benchmark: [
@@ -236,7 +236,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and bun-version
       benchmark: [
@@ -258,7 +258,7 @@ async function graph({
     )
     .map(b => ({
       ...b,
-      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : '',
+      opsLabel: b.ops ? b.ops.toLocaleString('en-US') : 'n/a',
       // artificical benchmark name to make sure its always sorted by
       // benchmark and deno-version
       benchmark: [
@@ -369,11 +369,24 @@ async function graph({
     spec: {
       layer: [
         {
+          // full-width track so benchmarks a library doesn't run still
+          // read as deliberate empty rows
+          mark: {
+            type: 'bar',
+            cornerRadius: 2,
+          },
+          width: chart.width,
+          encoding: {
+            x: { value: 0 },
+            x2: { value: chart.width },
+            color: { value: chart.trackColor },
+          },
+        },
+        {
           mark: {
             type: 'bar',
             cornerRadiusEnd: 2,
           },
-          width: chart.width,
         },
         {
           mark: {
@@ -400,6 +413,7 @@ async function graph({
             offset: 10,
             format: '~s',
             tickCount: 6,
+            grid: false,
             labelFontSize: 11,
             titleFontSize: 12.5,
             titleFontWeight: 'normal',

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -572,7 +572,7 @@ export class App extends Component<
 
   constructor() {
     super();
-    this.setState({
+    this.state = {
       darkMode: this.darkModeQuery.matches,
       selectedBenchmarks: BENCHMARKS.reduce(
         (acc, b) => ({ ...acc, [b.name]: true }),
@@ -585,7 +585,7 @@ export class App extends Component<
       valuesBun: [],
       valuesDeno: [],
       sortBy: 'fastest' as const,
-    });
+    };
   }
 
   getNodeJsVersions() {
@@ -886,26 +886,26 @@ export class App extends Component<
 
         <main class="chart">
           <Graph
-          benchmarks={BENCHMARKS.filter(
-            b => this.state.selectedBenchmarks[b.name]
-          )}
-          nodeJsVersions={Object.entries(this.state.selectedNodeJsVersions)
-            .sort()
-            .filter(entry => entry[1])
-            .map(entry => entry[0])}
-          bunVersions={Object.entries(this.state.selectedBunVersions)
-            .sort()
-            .filter(entry => entry[1])
-            .map(entry => entry[0])}
-          denoVersions={Object.entries(this.state.selectedDenoVersions)
-            .sort()
-            .filter(entry => entry[1])
-            .map(entry => entry[0])}
-          valuesNodeJs={this.state.valuesNodeJs}
-          valuesBun={this.state.valuesBun}
-          valuesDeno={this.state.valuesDeno}
-          sort={this.state.sortBy}
-          dark={this.state.darkMode}
+            benchmarks={BENCHMARKS.filter(
+              b => this.state.selectedBenchmarks[b.name]
+            )}
+            nodeJsVersions={Object.entries(this.state.selectedNodeJsVersions)
+              .sort()
+              .filter(entry => entry[1])
+              .map(entry => entry[0])}
+            bunVersions={Object.entries(this.state.selectedBunVersions)
+              .sort()
+              .filter(entry => entry[1])
+              .map(entry => entry[0])}
+            denoVersions={Object.entries(this.state.selectedDenoVersions)
+              .sort()
+              .filter(entry => entry[1])
+              .map(entry => entry[0])}
+            valuesNodeJs={this.state.valuesNodeJs}
+            valuesBun={this.state.valuesBun}
+            valuesDeno={this.state.valuesDeno}
+            sort={this.state.sortBy}
+            dark={this.state.darkMode}
           />
         </main>
 

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -1,4 +1,8 @@
 import { render } from 'preact';
 import { App } from './App.js';
+import { activeTheme } from './theme.js';
+import './styles.css';
+
+document.documentElement.dataset.theme = activeTheme().name;
 
 render(<App />, document.getElementById('root')!);

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -1,8 +1,5 @@
 import { render } from 'preact';
 import { App } from './App.js';
-import { activeTheme } from './theme.js';
 import './styles.css';
-
-document.documentElement.dataset.theme = activeTheme().name;
 
 render(<App />, document.getElementById('root')!);

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -1,79 +1,9 @@
 /* ---------------------------------------------------------------- */
-/* theme tokens                                                     */
+/* tokens                                                           */
 /* ---------------------------------------------------------------- */
 
 :root {
   color-scheme: light dark;
-  --c-parseSafe: #2a78d6;
-  --c-parseStrict: #eb6834;
-  --c-assertLoose: #1baf7a;
-  --c-assertStrict: #eda100;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --c-parseSafe: #3987e5;
-    --c-parseStrict: #d95926;
-    --c-assertLoose: #199e70;
-    --c-assertStrict: #c98500;
-  }
-}
-
-html[data-theme='report'] {
-  --bg: #fdfcfa;
-  --surface: #fdfcfa;
-  --ink: #1a1a19;
-  --ink-2: #52514e;
-  --ink-3: #898781;
-  --line: #e5e2dc;
-  --line-strong: #1a1a19;
-  --chip-bg: #f4f2ee;
-  --font-display: 'IBM Plex Sans', system-ui, sans-serif;
-  --font-body: 'IBM Plex Sans', system-ui, sans-serif;
-  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
-}
-
-@media (prefers-color-scheme: dark) {
-  html[data-theme='report'] {
-    --bg: #1b1b19;
-    --surface: #1b1b19;
-    --ink: #e8e6df;
-    --ink-2: #b3b1a7;
-    --ink-3: #898781;
-    --line: #33322e;
-    --line-strong: #e8e6df;
-    --chip-bg: #262521;
-  }
-}
-
-html[data-theme='panel'] {
-  --bg: #131317;
-  --surface: #1a1a20;
-  --ink: #e8e6df;
-  --ink-2: #a8a6ad;
-  --ink-3: #8b898f;
-  --line: #28282f;
-  --line-strong: #3c3c46;
-  --chip-bg: #202027;
-  --font-display: 'Space Grotesk', system-ui, sans-serif;
-  --font-body: 'Space Grotesk', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-}
-
-@media (prefers-color-scheme: light) {
-  html[data-theme='panel'] {
-    --bg: #f4f4f5;
-    --surface: #ffffff;
-    --ink: #1b1b20;
-    --ink-2: #4c4c55;
-    --ink-3: #77777f;
-    --line: #e2e2e6;
-    --line-strong: #1b1b20;
-    --chip-bg: #ececef;
-  }
-}
-
-html[data-theme='tool'] {
   --bg: #f3f4f6;
   --surface: #ffffff;
   --ink: #111827;
@@ -82,13 +12,16 @@ html[data-theme='tool'] {
   --line: #e5e7eb;
   --line-strong: #111827;
   --chip-bg: #f3f4f6;
-  --font-display: 'Inter', system-ui, sans-serif;
   --font-body: 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --c-parseSafe: #2a78d6;
+  --c-parseStrict: #eb6834;
+  --c-assertLoose: #1baf7a;
+  --c-assertStrict: #eda100;
 }
 
 @media (prefers-color-scheme: dark) {
-  html[data-theme='tool'] {
+  :root {
     --bg: #0f1115;
     --surface: #161a20;
     --ink: #e5e7eb;
@@ -97,6 +30,10 @@ html[data-theme='tool'] {
     --line: #262b33;
     --line-strong: #e5e7eb;
     --chip-bg: #1f242c;
+    --c-parseSafe: #3987e5;
+    --c-parseStrict: #d95926;
+    --c-assertLoose: #199e70;
+    --c-assertStrict: #c98500;
   }
 }
 
@@ -122,9 +59,17 @@ a {
 }
 
 .app {
-  max-width: 1080px;
+  max-width: 1180px;
   margin: 0 auto;
   padding: 2.5rem 2rem 4rem;
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  grid-template-areas:
+    'masthead masthead'
+    'controls main'
+    'docs docs';
+  gap: 1.5rem;
+  align-items: start;
 }
 
 /* ---------------------------------------------------------------- */
@@ -132,19 +77,18 @@ a {
 /* ---------------------------------------------------------------- */
 
 .masthead {
+  grid-area: masthead;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 2rem;
-  margin-bottom: 2rem;
 }
 
 .masthead h1 {
   margin: 0 0 0.3rem;
-  font-family: var(--font-display);
-  font-size: 2rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: 1.7rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
   line-height: 1.1;
 }
 
@@ -203,17 +147,26 @@ a {
 }
 
 /* ---------------------------------------------------------------- */
-/* controls                                                         */
+/* controls sidebar                                                 */
 /* ---------------------------------------------------------------- */
 
 .controls {
+  grid-area: controls;
+  position: sticky;
+  top: 1.5rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem 2.5rem;
-  padding: 1.1rem 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-  margin-bottom: 1.5rem;
+  flex-direction: column;
+  gap: 1.3rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 1.2rem;
+}
+
+.control-group {
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .control-group legend,
@@ -226,12 +179,6 @@ a {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--ink-3);
-}
-
-.control-group {
-  border: 0;
-  margin: 0;
-  padding: 0;
 }
 
 .chip-row {
@@ -309,6 +256,11 @@ a {
 /* ---------------------------------------------------------------- */
 
 .chart {
+  grid-area: main;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 1.5rem;
   overflow-x: auto;
 }
 
@@ -323,12 +275,11 @@ a {
 /* ---------------------------------------------------------------- */
 
 .bench-docs {
+  grid-area: docs;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   gap: 1rem;
-  margin-top: 2.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--line);
+  margin-top: 1rem;
 }
 
 .bench-doc {
@@ -361,114 +312,24 @@ a {
 }
 
 /* ---------------------------------------------------------------- */
-/* theme: report — document feel                                    */
+/* responsive                                                       */
 /* ---------------------------------------------------------------- */
-
-html[data-theme='report'] .masthead {
-  padding-bottom: 1.4rem;
-  border-bottom: 2px solid var(--line-strong);
-  margin-bottom: 0;
-}
-
-html[data-theme='report'] .controls {
-  border-top: 0;
-}
-
-html[data-theme='report'] .masthead h1 {
-  font-weight: 600;
-  font-size: 2.1rem;
-}
-
-/* ---------------------------------------------------------------- */
-/* theme: panel — instrument feel                                   */
-/* ---------------------------------------------------------------- */
-
-html[data-theme='panel'] .controls {
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 1.1rem 1.3rem;
-  background: var(--surface);
-}
-
-html[data-theme='panel'] .chip {
-  background: var(--chip-bg);
-  border-color: transparent;
-}
-
-html[data-theme='panel'] .chip.checked {
-  border-color: var(--line-strong);
-}
-
-html[data-theme='panel'] .masthead h1 {
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-html[data-theme='panel'] .updated::before {
-  content: '● ';
-  color: var(--c-assertLoose);
-}
-
-/* ---------------------------------------------------------------- */
-/* theme: tool — workspace feel                                     */
-/* ---------------------------------------------------------------- */
-
-html[data-theme='tool'] .app {
-  max-width: 1180px;
-  display: grid;
-  grid-template-columns: 232px minmax(0, 1fr);
-  grid-template-areas:
-    'masthead masthead'
-    'controls main'
-    'docs docs';
-  gap: 1.5rem;
-  align-items: start;
-}
-
-html[data-theme='tool'] .masthead {
-  grid-area: masthead;
-  margin-bottom: 0;
-}
-
-html[data-theme='tool'] .controls {
-  grid-area: controls;
-  position: sticky;
-  top: 1.5rem;
-  flex-direction: column;
-  gap: 1.3rem;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--surface);
-  padding: 1.2rem;
-  margin-bottom: 0;
-}
-
-html[data-theme='tool'] .chart {
-  grid-area: main;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--surface);
-  padding: 1.5rem;
-}
-
-html[data-theme='tool'] .bench-docs {
-  grid-area: docs;
-  border-top: 0;
-  padding-top: 0;
-}
-
-html[data-theme='tool'] .masthead h1 {
-  font-size: 1.7rem;
-  letter-spacing: -0.03em;
-}
 
 @media (max-width: 900px) {
-  html[data-theme='tool'] .app {
+  .app {
     display: block;
   }
 
-  html[data-theme='tool'] .controls {
+  .masthead {
+    margin-bottom: 1.5rem;
+  }
+
+  .controls {
     position: static;
+    margin-bottom: 1.5rem;
+  }
+
+  .chart {
     margin-bottom: 1.5rem;
   }
 }

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -14,6 +14,7 @@
   --chip-bg: #f3f4f6;
   --font-body: 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --card-pad: 1.25rem;
   --c-parseSafe: #2a78d6;
   --c-parseStrict: #eb6834;
   --c-assertLoose: #1baf7a;
@@ -150,17 +151,25 @@ a {
 /* controls sidebar                                                 */
 /* ---------------------------------------------------------------- */
 
-.controls {
+/* the wrapper spans the whole row so the sticky card stops at the chart's
+   bottom edge instead of riding over the descriptions below */
+.controls-col {
   grid-area: controls;
+  align-self: stretch;
+}
+
+.controls {
   position: sticky;
   top: 1.5rem;
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1.3rem;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: var(--surface);
-  padding: 1.2rem;
+  padding: var(--card-pad);
 }
 
 .control-group {
@@ -260,14 +269,26 @@ a {
   border: 1px solid var(--line);
   border-radius: 10px;
   background: var(--surface);
-  padding: 1.5rem;
+  padding: var(--card-pad);
   overflow-x: auto;
 }
 
-.chart .empty {
-  margin: 5rem 0;
+.chart-caption {
+  margin: 0 0 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ink-2);
+}
+
+.chart-caption span {
   color: var(--ink-3);
-  font-style: italic;
+  font-weight: 400;
+}
+
+.chart .empty {
+  margin: 4rem 0;
+  text-align: center;
+  color: var(--ink-3);
 }
 
 /* ---------------------------------------------------------------- */
@@ -283,7 +304,7 @@ a {
 }
 
 .bench-doc {
-  padding: 1rem 1.1rem;
+  padding: var(--card-pad);
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--surface);
@@ -326,6 +347,7 @@ a {
 
   .controls {
     position: static;
+    max-height: none;
     margin-bottom: 1.5rem;
   }
 

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -1,0 +1,446 @@
+/* ---------------------------------------------------------------- */
+/* theme tokens                                                     */
+/* ---------------------------------------------------------------- */
+
+:root {
+  --c-parseSafe: #2a78d6;
+  --c-parseStrict: #eb6834;
+  --c-assertLoose: #1baf7a;
+  --c-assertStrict: #eda100;
+}
+
+html[data-theme='report'] {
+  color-scheme: light;
+  --bg: #fdfcfa;
+  --surface: #fdfcfa;
+  --ink: #1a1a19;
+  --ink-2: #52514e;
+  --ink-3: #898781;
+  --line: #e5e2dc;
+  --line-strong: #1a1a19;
+  --chip-bg: #f4f2ee;
+  --chip-checked: #1a1a19;
+  --font-display: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-body: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+html[data-theme='panel'] {
+  color-scheme: dark;
+  --bg: #131317;
+  --surface: #1a1a20;
+  --ink: #e8e6df;
+  --ink-2: #a8a6ad;
+  --ink-3: #8b898f;
+  --line: #28282f;
+  --line-strong: #3c3c46;
+  --chip-bg: #202027;
+  --chip-checked: #e8e6df;
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'Space Grotesk', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --c-parseSafe: #3987e5;
+  --c-parseStrict: #d95926;
+  --c-assertLoose: #199e70;
+  --c-assertStrict: #c98500;
+}
+
+html[data-theme='tool'] {
+  color-scheme: light;
+  --bg: #f3f4f6;
+  --surface: #ffffff;
+  --ink: #111827;
+  --ink-2: #4b5563;
+  --ink-3: #9ca3af;
+  --line: #e5e7eb;
+  --line-strong: #111827;
+  --chip-bg: #f3f4f6;
+  --chip-checked: #111827;
+  --font-display: 'Inter', system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* ---------------------------------------------------------------- */
+/* base                                                             */
+/* ---------------------------------------------------------------- */
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+}
+
+.app {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 2rem 4rem;
+}
+
+/* ---------------------------------------------------------------- */
+/* masthead                                                         */
+/* ---------------------------------------------------------------- */
+
+.masthead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.masthead h1 {
+  margin: 0 0 0.3rem;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.masthead .strip {
+  display: flex;
+  gap: 4px;
+  margin: 0.65rem 0 0.9rem;
+}
+
+.masthead .strip span {
+  height: 4px;
+  width: 34px;
+  border-radius: 2px;
+}
+
+.tagline {
+  margin: 0;
+  max-width: 34rem;
+  color: var(--ink-2);
+}
+
+.updated {
+  margin: 0.5rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--ink-3);
+}
+
+.gh-links {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.gh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink-2);
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.gh-btn:hover {
+  border-color: var(--line-strong);
+  color: var(--ink);
+}
+
+.gh-btn svg {
+  fill: currentColor;
+}
+
+/* ---------------------------------------------------------------- */
+/* controls                                                         */
+/* ---------------------------------------------------------------- */
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+  padding: 1.1rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 1.5rem;
+}
+
+.control-group legend,
+.control-group .group-label {
+  display: block;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.control-group {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--ink-2);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chip input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.chip .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--dot, var(--ink-3));
+  opacity: 0.35;
+}
+
+.chip:hover {
+  border-color: var(--line-strong);
+}
+
+.chip.checked {
+  border-color: var(--line-strong);
+  color: var(--ink);
+  background: var(--chip-bg);
+}
+
+.chip.checked .dot {
+  opacity: 1;
+}
+
+.chip:has(input:focus-visible) {
+  outline: 2px solid var(--c-parseSafe);
+  outline-offset: 2px;
+}
+
+.sort-select {
+  appearance: none;
+  padding: 0.35rem 1.9rem 0.35rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background-color: var(--surface);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23898781' fill='none' stroke-width='1.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.6rem center;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+/* ---------------------------------------------------------------- */
+/* chart                                                            */
+/* ---------------------------------------------------------------- */
+
+.chart {
+  overflow-x: auto;
+}
+
+.chart .empty {
+  margin: 5rem 0;
+  color: var(--ink-3);
+  font-style: italic;
+}
+
+/* ---------------------------------------------------------------- */
+/* benchmark descriptions                                           */
+/* ---------------------------------------------------------------- */
+
+.bench-docs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.bench-doc {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.bench-doc h4 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.bench-doc h4 .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.bench-doc p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ink-2);
+}
+
+/* ---------------------------------------------------------------- */
+/* theme: report — document feel                                    */
+/* ---------------------------------------------------------------- */
+
+html[data-theme='report'] .masthead {
+  padding-bottom: 1.4rem;
+  border-bottom: 2px solid var(--line-strong);
+  margin-bottom: 0;
+}
+
+html[data-theme='report'] .controls {
+  border-top: 0;
+}
+
+html[data-theme='report'] .masthead h1 {
+  font-weight: 600;
+  font-size: 2.1rem;
+}
+
+/* ---------------------------------------------------------------- */
+/* theme: panel — instrument feel                                   */
+/* ---------------------------------------------------------------- */
+
+html[data-theme='panel'] .controls {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 1.1rem 1.3rem;
+  background: var(--surface);
+}
+
+html[data-theme='panel'] .chip {
+  background: var(--chip-bg);
+  border-color: transparent;
+}
+
+html[data-theme='panel'] .chip.checked {
+  border-color: var(--line-strong);
+}
+
+html[data-theme='panel'] .masthead h1 {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+html[data-theme='panel'] .updated::before {
+  content: '● ';
+  color: var(--c-assertLoose);
+}
+
+/* ---------------------------------------------------------------- */
+/* theme: tool — workspace feel                                     */
+/* ---------------------------------------------------------------- */
+
+html[data-theme='tool'] .app {
+  max-width: 1180px;
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  grid-template-areas:
+    'masthead masthead'
+    'controls main'
+    'docs docs';
+  gap: 1.5rem;
+  align-items: start;
+}
+
+html[data-theme='tool'] .masthead {
+  grid-area: masthead;
+  margin-bottom: 0;
+}
+
+html[data-theme='tool'] .controls {
+  grid-area: controls;
+  position: sticky;
+  top: 1.5rem;
+  flex-direction: column;
+  gap: 1.3rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 1.2rem;
+  margin-bottom: 0;
+}
+
+html[data-theme='tool'] .chart {
+  grid-area: main;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 1.5rem;
+}
+
+html[data-theme='tool'] .bench-docs {
+  grid-area: docs;
+  border-top: 0;
+  padding-top: 0;
+}
+
+html[data-theme='tool'] .masthead h1 {
+  font-size: 1.7rem;
+  letter-spacing: -0.03em;
+}
+
+@media (max-width: 900px) {
+  html[data-theme='tool'] .app {
+    display: block;
+  }
+
+  html[data-theme='tool'] .controls {
+    position: static;
+    margin-bottom: 1.5rem;
+  }
+}
+
+@media (max-width: 700px) {
+  .app {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .masthead {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -3,14 +3,23 @@
 /* ---------------------------------------------------------------- */
 
 :root {
+  color-scheme: light dark;
   --c-parseSafe: #2a78d6;
   --c-parseStrict: #eb6834;
   --c-assertLoose: #1baf7a;
   --c-assertStrict: #eda100;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --c-parseSafe: #3987e5;
+    --c-parseStrict: #d95926;
+    --c-assertLoose: #199e70;
+    --c-assertStrict: #c98500;
+  }
+}
+
 html[data-theme='report'] {
-  color-scheme: light;
   --bg: #fdfcfa;
   --surface: #fdfcfa;
   --ink: #1a1a19;
@@ -19,14 +28,25 @@ html[data-theme='report'] {
   --line: #e5e2dc;
   --line-strong: #1a1a19;
   --chip-bg: #f4f2ee;
-  --chip-checked: #1a1a19;
   --font-display: 'IBM Plex Sans', system-ui, sans-serif;
   --font-body: 'IBM Plex Sans', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
 }
 
+@media (prefers-color-scheme: dark) {
+  html[data-theme='report'] {
+    --bg: #1b1b19;
+    --surface: #1b1b19;
+    --ink: #e8e6df;
+    --ink-2: #b3b1a7;
+    --ink-3: #898781;
+    --line: #33322e;
+    --line-strong: #e8e6df;
+    --chip-bg: #262521;
+  }
+}
+
 html[data-theme='panel'] {
-  color-scheme: dark;
   --bg: #131317;
   --surface: #1a1a20;
   --ink: #e8e6df;
@@ -35,18 +55,25 @@ html[data-theme='panel'] {
   --line: #28282f;
   --line-strong: #3c3c46;
   --chip-bg: #202027;
-  --chip-checked: #e8e6df;
   --font-display: 'Space Grotesk', system-ui, sans-serif;
   --font-body: 'Space Grotesk', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
-  --c-parseSafe: #3987e5;
-  --c-parseStrict: #d95926;
-  --c-assertLoose: #199e70;
-  --c-assertStrict: #c98500;
+}
+
+@media (prefers-color-scheme: light) {
+  html[data-theme='panel'] {
+    --bg: #f4f4f5;
+    --surface: #ffffff;
+    --ink: #1b1b20;
+    --ink-2: #4c4c55;
+    --ink-3: #77777f;
+    --line: #e2e2e6;
+    --line-strong: #1b1b20;
+    --chip-bg: #ececef;
+  }
 }
 
 html[data-theme='tool'] {
-  color-scheme: light;
   --bg: #f3f4f6;
   --surface: #ffffff;
   --ink: #111827;
@@ -55,10 +82,22 @@ html[data-theme='tool'] {
   --line: #e5e7eb;
   --line-strong: #111827;
   --chip-bg: #f3f4f6;
-  --chip-checked: #111827;
   --font-display: 'Inter', system-ui, sans-serif;
   --font-body: 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='tool'] {
+    --bg: #0f1115;
+    --surface: #161a20;
+    --ink: #e5e7eb;
+    --ink-2: #9ca3af;
+    --ink-3: #6b7280;
+    --line: #262b33;
+    --line-strong: #e5e7eb;
+    --chip-bg: #1f242c;
+  }
 }
 
 /* ---------------------------------------------------------------- */

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -18,6 +18,8 @@ export interface ChartTheme {
   gridColor: string;
   /** axis domain/tick color */
   domainColor: string;
+  /** full-width row track behind each bar */
+  trackColor: string;
   /** bar plot width in px */
   width: number;
 }
@@ -42,6 +44,7 @@ export const CHART: { light: ChartTheme; dark: ChartTheme } = {
     valueColor: '#6b7280',
     gridColor: '#f3f4f6',
     domainColor: '#e5e7eb',
+    trackColor: '#f1f3f5',
     width: 470,
   },
   dark: {
@@ -58,6 +61,7 @@ export const CHART: { light: ChartTheme; dark: ChartTheme } = {
     valueColor: '#9ca3af',
     gridColor: '#1f242c',
     domainColor: '#333a44',
+    trackColor: '#20252d',
     width: 470,
   },
 };

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -1,0 +1,101 @@
+// Visual themes. The active theme is picked via the `?theme=` query
+// parameter (mockup switch); `report` is the default.
+
+export interface ChartTheme {
+  /** color per benchmark name, stable across the whole page */
+  series: { [benchmark: string]: string };
+  /** font stack for axis labels and facet headers */
+  font: string;
+  /** monospaced stack for numbers */
+  monoFont: string;
+  /** facet header (library name) color */
+  headerColor: string;
+  /** axis label color */
+  axisColor: string;
+  /** bar value label color */
+  valueColor: string;
+  /** grid line color ('' disables the grid) */
+  gridColor: string;
+  /** axis domain/tick color */
+  domainColor: string;
+  /** bar plot width in px */
+  width: number;
+}
+
+export interface Theme {
+  name: string;
+  chart: ChartTheme;
+}
+
+const PLEX_SANS = "'IBM Plex Sans', system-ui, sans-serif";
+const PLEX_MONO = "'IBM Plex Mono', ui-monospace, monospace";
+const GROTESK = "'Space Grotesk', system-ui, sans-serif";
+const JET_MONO = "'JetBrains Mono', ui-monospace, monospace";
+const INTER = "'Inter', system-ui, sans-serif";
+
+// categorical palettes validated for CVD separation + contrast
+// (order: parseSafe, parseStrict, assertLoose, assertStrict)
+const SERIES_LIGHT = {
+  parseSafe: '#2a78d6',
+  parseStrict: '#eb6834',
+  assertLoose: '#1baf7a',
+  assertStrict: '#eda100',
+};
+
+const SERIES_DARK = {
+  parseSafe: '#3987e5',
+  parseStrict: '#d95926',
+  assertLoose: '#199e70',
+  assertStrict: '#c98500',
+};
+
+export const THEMES: { [name: string]: Theme } = {
+  report: {
+    name: 'report',
+    chart: {
+      series: SERIES_LIGHT,
+      font: PLEX_SANS,
+      monoFont: PLEX_MONO,
+      headerColor: '#1a1a19',
+      axisColor: '#898781',
+      valueColor: '#52514e',
+      gridColor: '#efedea',
+      domainColor: '#d8d5d0',
+      width: 600,
+    },
+  },
+  panel: {
+    name: 'panel',
+    chart: {
+      series: SERIES_DARK,
+      font: GROTESK,
+      monoFont: JET_MONO,
+      headerColor: '#e8e6df',
+      axisColor: '#8b898f',
+      valueColor: '#a8a6ad',
+      gridColor: '#26262e',
+      domainColor: '#3a3a44',
+      width: 600,
+    },
+  },
+  tool: {
+    name: 'tool',
+    chart: {
+      series: SERIES_LIGHT,
+      font: INTER,
+      monoFont: JET_MONO,
+      headerColor: '#111827',
+      axisColor: '#9ca3af',
+      valueColor: '#6b7280',
+      gridColor: '#f3f4f6',
+      domainColor: '#e5e7eb',
+      width: 470,
+    },
+  },
+};
+
+export function activeTheme(): Theme {
+  const name = new URLSearchParams(window.location.search).get('theme');
+
+  return (name && THEMES[name]) || THEMES.report;
+}

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -1,5 +1,6 @@
 // Visual themes. The active theme is picked via the `?theme=` query
-// parameter (mockup switch); `report` is the default.
+// parameter (mockup switch); `report` is the default. Each theme has a
+// light and a dark chart config, chosen by prefers-color-scheme.
 
 export interface ChartTheme {
   /** color per benchmark name, stable across the whole page */
@@ -14,7 +15,7 @@ export interface ChartTheme {
   axisColor: string;
   /** bar value label color */
   valueColor: string;
-  /** grid line color ('' disables the grid) */
+  /** grid line color */
   gridColor: string;
   /** axis domain/tick color */
   domainColor: string;
@@ -24,7 +25,7 @@ export interface ChartTheme {
 
 export interface Theme {
   name: string;
-  chart: ChartTheme;
+  chart: { light: ChartTheme; dark: ChartTheme };
 }
 
 const PLEX_SANS = "'IBM Plex Sans', system-ui, sans-serif";
@@ -53,43 +54,82 @@ export const THEMES: { [name: string]: Theme } = {
   report: {
     name: 'report',
     chart: {
-      series: SERIES_LIGHT,
-      font: PLEX_SANS,
-      monoFont: PLEX_MONO,
-      headerColor: '#1a1a19',
-      axisColor: '#898781',
-      valueColor: '#52514e',
-      gridColor: '#efedea',
-      domainColor: '#d8d5d0',
-      width: 600,
+      light: {
+        series: SERIES_LIGHT,
+        font: PLEX_SANS,
+        monoFont: PLEX_MONO,
+        headerColor: '#1a1a19',
+        axisColor: '#898781',
+        valueColor: '#52514e',
+        gridColor: '#efedea',
+        domainColor: '#d8d5d0',
+        width: 600,
+      },
+      dark: {
+        series: SERIES_DARK,
+        font: PLEX_SANS,
+        monoFont: PLEX_MONO,
+        headerColor: '#e8e6df',
+        axisColor: '#898781',
+        valueColor: '#a3a19a',
+        gridColor: '#262521',
+        domainColor: '#3a3934',
+        width: 600,
+      },
     },
   },
   panel: {
     name: 'panel',
     chart: {
-      series: SERIES_DARK,
-      font: GROTESK,
-      monoFont: JET_MONO,
-      headerColor: '#e8e6df',
-      axisColor: '#8b898f',
-      valueColor: '#a8a6ad',
-      gridColor: '#26262e',
-      domainColor: '#3a3a44',
-      width: 600,
+      light: {
+        series: SERIES_LIGHT,
+        font: GROTESK,
+        monoFont: JET_MONO,
+        headerColor: '#1b1b20',
+        axisColor: '#8b8b93',
+        valueColor: '#62626b',
+        gridColor: '#ececef',
+        domainColor: '#d5d5da',
+        width: 600,
+      },
+      dark: {
+        series: SERIES_DARK,
+        font: GROTESK,
+        monoFont: JET_MONO,
+        headerColor: '#e8e6df',
+        axisColor: '#8b898f',
+        valueColor: '#a8a6ad',
+        gridColor: '#26262e',
+        domainColor: '#3a3a44',
+        width: 600,
+      },
     },
   },
   tool: {
     name: 'tool',
     chart: {
-      series: SERIES_LIGHT,
-      font: INTER,
-      monoFont: JET_MONO,
-      headerColor: '#111827',
-      axisColor: '#9ca3af',
-      valueColor: '#6b7280',
-      gridColor: '#f3f4f6',
-      domainColor: '#e5e7eb',
-      width: 470,
+      light: {
+        series: SERIES_LIGHT,
+        font: INTER,
+        monoFont: JET_MONO,
+        headerColor: '#111827',
+        axisColor: '#9ca3af',
+        valueColor: '#6b7280',
+        gridColor: '#f3f4f6',
+        domainColor: '#e5e7eb',
+        width: 470,
+      },
+      dark: {
+        series: SERIES_DARK,
+        font: INTER,
+        monoFont: JET_MONO,
+        headerColor: '#e5e7eb',
+        axisColor: '#6b7280',
+        valueColor: '#9ca3af',
+        gridColor: '#1f242c',
+        domainColor: '#333a44',
+        width: 470,
+      },
     },
   },
 };

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -20,8 +20,6 @@ export interface ChartTheme {
   domainColor: string;
   /** full-width row track behind each bar */
   trackColor: string;
-  /** bar plot width in px */
-  width: number;
 }
 
 const INTER = "'Inter', system-ui, sans-serif";
@@ -45,7 +43,6 @@ export const CHART: { light: ChartTheme; dark: ChartTheme } = {
     gridColor: '#f3f4f6',
     domainColor: '#e5e7eb',
     trackColor: '#f1f3f5',
-    width: 470,
   },
   dark: {
     series: {
@@ -62,6 +59,5 @@ export const CHART: { light: ChartTheme; dark: ChartTheme } = {
     gridColor: '#1f242c',
     domainColor: '#333a44',
     trackColor: '#20252d',
-    width: 470,
   },
 };

--- a/docs/src/theme.ts
+++ b/docs/src/theme.ts
@@ -1,6 +1,5 @@
-// Visual themes. The active theme is picked via the `?theme=` query
-// parameter (mockup switch); `report` is the default. Each theme has a
-// light and a dark chart config, chosen by prefers-color-scheme.
+// Chart styling, one config per color scheme. Page styling lives in
+// styles.css; these values only reach the vega spec.
 
 export interface ChartTheme {
   /** color per benchmark name, stable across the whole page */
@@ -23,119 +22,42 @@ export interface ChartTheme {
   width: number;
 }
 
-export interface Theme {
-  name: string;
-  chart: { light: ChartTheme; dark: ChartTheme };
-}
-
-const PLEX_SANS = "'IBM Plex Sans', system-ui, sans-serif";
-const PLEX_MONO = "'IBM Plex Mono', ui-monospace, monospace";
-const GROTESK = "'Space Grotesk', system-ui, sans-serif";
-const JET_MONO = "'JetBrains Mono', ui-monospace, monospace";
 const INTER = "'Inter', system-ui, sans-serif";
+const JET_MONO = "'JetBrains Mono', ui-monospace, monospace";
 
 // categorical palettes validated for CVD separation + contrast
 // (order: parseSafe, parseStrict, assertLoose, assertStrict)
-const SERIES_LIGHT = {
-  parseSafe: '#2a78d6',
-  parseStrict: '#eb6834',
-  assertLoose: '#1baf7a',
-  assertStrict: '#eda100',
-};
-
-const SERIES_DARK = {
-  parseSafe: '#3987e5',
-  parseStrict: '#d95926',
-  assertLoose: '#199e70',
-  assertStrict: '#c98500',
-};
-
-export const THEMES: { [name: string]: Theme } = {
-  report: {
-    name: 'report',
-    chart: {
-      light: {
-        series: SERIES_LIGHT,
-        font: PLEX_SANS,
-        monoFont: PLEX_MONO,
-        headerColor: '#1a1a19',
-        axisColor: '#898781',
-        valueColor: '#52514e',
-        gridColor: '#efedea',
-        domainColor: '#d8d5d0',
-        width: 600,
-      },
-      dark: {
-        series: SERIES_DARK,
-        font: PLEX_SANS,
-        monoFont: PLEX_MONO,
-        headerColor: '#e8e6df',
-        axisColor: '#898781',
-        valueColor: '#a3a19a',
-        gridColor: '#262521',
-        domainColor: '#3a3934',
-        width: 600,
-      },
+export const CHART: { light: ChartTheme; dark: ChartTheme } = {
+  light: {
+    series: {
+      parseSafe: '#2a78d6',
+      parseStrict: '#eb6834',
+      assertLoose: '#1baf7a',
+      assertStrict: '#eda100',
     },
+    font: INTER,
+    monoFont: JET_MONO,
+    headerColor: '#111827',
+    axisColor: '#9ca3af',
+    valueColor: '#6b7280',
+    gridColor: '#f3f4f6',
+    domainColor: '#e5e7eb',
+    width: 470,
   },
-  panel: {
-    name: 'panel',
-    chart: {
-      light: {
-        series: SERIES_LIGHT,
-        font: GROTESK,
-        monoFont: JET_MONO,
-        headerColor: '#1b1b20',
-        axisColor: '#8b8b93',
-        valueColor: '#62626b',
-        gridColor: '#ececef',
-        domainColor: '#d5d5da',
-        width: 600,
-      },
-      dark: {
-        series: SERIES_DARK,
-        font: GROTESK,
-        monoFont: JET_MONO,
-        headerColor: '#e8e6df',
-        axisColor: '#8b898f',
-        valueColor: '#a8a6ad',
-        gridColor: '#26262e',
-        domainColor: '#3a3a44',
-        width: 600,
-      },
+  dark: {
+    series: {
+      parseSafe: '#3987e5',
+      parseStrict: '#d95926',
+      assertLoose: '#199e70',
+      assertStrict: '#c98500',
     },
-  },
-  tool: {
-    name: 'tool',
-    chart: {
-      light: {
-        series: SERIES_LIGHT,
-        font: INTER,
-        monoFont: JET_MONO,
-        headerColor: '#111827',
-        axisColor: '#9ca3af',
-        valueColor: '#6b7280',
-        gridColor: '#f3f4f6',
-        domainColor: '#e5e7eb',
-        width: 470,
-      },
-      dark: {
-        series: SERIES_DARK,
-        font: INTER,
-        monoFont: JET_MONO,
-        headerColor: '#e5e7eb',
-        axisColor: '#6b7280',
-        valueColor: '#9ca3af',
-        gridColor: '#1f242c',
-        domainColor: '#333a44',
-        width: 470,
-      },
-    },
+    font: INTER,
+    monoFont: JET_MONO,
+    headerColor: '#e5e7eb',
+    axisColor: '#6b7280',
+    valueColor: '#9ca3af',
+    gridColor: '#1f242c',
+    domainColor: '#333a44',
+    width: 470,
   },
 };
-
-export function activeTheme(): Theme {
-  const name = new URLSearchParams(window.location.search).get('theme');
-
-  return (name && THEMES[name]) || THEMES.report;
-}


### PR DESCRIPTION
A visual refresh of the results site. `docs/` only — no data or benchmark changes, and all existing functionality (benchmark/runtime filters, sort, light + dark via the OS preference) works as before.

**Before:**

![before, light mode](https://raw.githubusercontent.com/colinhacks/typescript-runtime-type-benchmarks/docs-redesign-assets/baseline-light.png)

**After:**

![after, light mode](https://raw.githubusercontent.com/colinhacks/typescript-runtime-type-benchmarks/docs-redesign-assets/final-light.png)

![after, dark mode](https://raw.githubusercontent.com/colinhacks/typescript-runtime-type-benchmarks/docs-redesign-assets/final-dark.png)

What changed:

- Replaces water.css and the inline styles with a small stylesheet: filters in a sticky sidebar, the chart on a card, the benchmark descriptions in a grid of cards. Single-column below 900px.
- New chart palette with one stable color per benchmark. The four colors pass colorblind-separation (CVD) checks against both surfaces; the old Set3 pastels also colored the value labels, which made them hard to read in light mode.
- Every row gets a full-width track, and a benchmark a library doesn't implement reads as `n/a` on an empty track. Previously those rows printed `0` against an axis where zero is indistinguishable from a missing bar.
- The plot is sized from its container rather than a fixed 600px, so value labels and the last axis tick no longer get clipped between roughly 1000 and 1300px wide. Long library names truncate on narrow screens instead of squeezing the bars out of view.
- Selecting more than one runtime version now labels each bar with its version. Previously the repeated bars were the same color with nothing to tell them apart.
- Value labels are abbreviated (`81.8M`) with the exact figure on hover, and the scale reserves that label's width inside the row track, so no label overhangs the track at any width.
- The chart SVG re-renders on an OS color-scheme change; previously it kept the old label colors until reload.
- The Star/Fork buttons have rendered as bare text links since the Vite migration dropped the github-buttons script; they're now styled links with inline octicons, no external script.
- Fonts: Inter and JetBrains Mono from Google Fonts.

`npm run lint` and `npm run build` pass in `docs/`.
