### PR TITLE
Consume each benchmark result so the engine cannot delete the work

### DIFF
--- a/benchmarks/assertLoose.ts
+++ b/benchmarks/assertLoose.ts
@@ -16,7 +16,7 @@ type Fn = (data: unknown) => boolean;
  */
 export class AssertLoose extends Benchmark<Fn> {
   run() {
-    this.fn(validateData);
+    this.sink = this.fn(validateData);
   }
 
   test(describe: SuiteAPI, expect: ExpectStatic, test: TestAPI) {

--- a/benchmarks/assertStrict.ts
+++ b/benchmarks/assertStrict.ts
@@ -11,7 +11,7 @@ type Fn = (data: unknown) => boolean;
  */
 export class AssertStrict extends Benchmark<Fn> {
   run() {
-    this.fn(validateData);
+    this.sink = this.fn(validateData);
   }
 
   test(describe: SuiteAPI, expect: ExpectStatic, test: TestAPI) {

--- a/benchmarks/helpers/types.ts
+++ b/benchmarks/helpers/types.ts
@@ -17,6 +17,12 @@ export abstract class Benchmark<Fn> implements BenchmarkCase {
   // the function that implements the benchmark
   readonly fn: Fn;
 
+  // Each run() assigns its result here. Without that, a validator small enough
+  // for the engine to inline has its result treated as dead: V8's escape
+  // analysis then deletes the allocation the benchmark is supposed to measure,
+  // and the library is credited with work it never did.
+  protected sink: unknown;
+
   constructor(moduleName: string, fn: Fn) {
     this.moduleName = moduleName;
     this.fn = fn;

--- a/benchmarks/parseSafe.ts
+++ b/benchmarks/parseSafe.ts
@@ -27,7 +27,7 @@ type Fn = (data: unknown) => typeof validateData;
  */
 export class ParseSafe extends Benchmark<Fn> {
   run() {
-    this.fn(validateData);
+    this.sink = this.fn(validateData);
   }
 
   test(describe: SuiteAPI, expect: ExpectStatic, test: TestAPI) {

--- a/benchmarks/parseStrict.ts
+++ b/benchmarks/parseStrict.ts
@@ -9,7 +9,7 @@ type Fn = (data: unknown) => typeof validateData;
  */
 export class ParseStrict extends Benchmark<Fn> {
   run() {
-    this.fn(validateData);
+    this.sink = this.fn(validateData);
   }
 
   test(describe: SuiteAPI, expect: ExpectStatic, test: TestAPI) {


### PR DESCRIPTION
All four benchmarks call the validator and throw the result away:

```ts
run() {
  this.fn(validateData);
}
```

Combined with a single frozen `validateData` reused every iteration, that lets V8 delete the work being measured. When a validator is small enough to inline and its result is never read, escape analysis scalar-replaces the allocation and it never happens.

The effect is easy to see in isolation. Same inlinable clone function, same input, only the handling of the result differs:

```
result discarded      2242.2M ops/s
assigned to a field     61.0M ops/s
```

2.2 billion ops/s is not a fast validator, it is no validator. Whatever the loop was supposed to measure is gone.

## What it does to the results

This lands unevenly, because it only pays out for a library the engine can inline. Measured in this harness, changing only `run()` to keep the result:

| benchmark | library | discarded | consumed | change |
| --- | --- | --- | --- | --- |
| parseSafe | typia | 86.6M | 45.1M | **-48%** |
| parseSafe | zod (compiled) | 57.9M | 48.1M | -17% |
| parseStrict | typia | 35.2M | 34.5M | -2% |

`parseStrict` is the control: typia returns the input unchanged there, so there is no allocation to remove, and consuming the result costs nothing. The drop lands only where typia allocates. zod also collects some of it, less, because its generated parse function is too large to inline.

That is enough to change the ordering — parseSafe goes from typia ahead by 1.49x to zod ahead by 1.06x.

## The change

A `sink` field on `Benchmark`, assigned by each `run()`. Assigning to an instance field and to a module-level binding measure the same (61.0M vs 60.0M ops/s), so this is the least invasive form.

## Caveats

My machine was heavily loaded, so treat the absolute numbers as soft — the controls are what make the parseSafe result trustworthy, not the precision. Your CI numbers are the authority, and re-running the full suite on this branch is the real test.

Disclosure: I maintain zod, and this change lowers a benchmark where typia currently leads it. I would rather raise it than have the numbers quietly favour whichever library happens to be inlinable, but you should verify the mechanism yourself rather than take my word for it. The isolated reproduction above needs no benchmark harness at all.
