### PR TITLE
Regenerate results when a benchmark definition changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - master
     paths:
       - .github/workflows/*.yml
+      - "benchmarks/**"
       - "cases/*.ts"
       - "*.ts"
       - package.json


### PR DESCRIPTION
The release workflow regenerates `docs/results/` on push to `master`, and its `paths:` filter lists the library adapters, the root scripts and the manifests. Edits under `benchmarks/` fall outside it, so a change to what a benchmark measures can land without the published numbers being regenerated alongside it.

That's what happened with #2353 — it changed all four `run()` methods, and the Pages deploy was the only workflow to run on the merge, so the results currently on the site predate it.

`pr.yml` has no path filter, so changes under `benchmarks/` are already built and tested on the pull request. This brings the release trigger in line with that.

`benchmarks/**` rather than `benchmarks/*.ts` because the harness has a subdirectory — `benchmarks/helpers/types.ts` holds the `Benchmark` base class the four suites extend.
