### PR TITLE
feat: add ata-validator parseSafe and parseStrict benchmarks

### DIFF
--- a/cases/ata-aot/index.ts
+++ b/cases/ata-aot/index.ts
@@ -1,4 +1,4 @@
-import { isValidLoose, isValidStrict } from './build';
+import { isValidLoose, isValidStrict, parseSanitized } from './build';
 import { createCase } from '../../benchmarks';
 
 // Ahead-of-time counterpart to the runtime `ata` case. `ata compile` turns a
@@ -24,5 +24,19 @@ createCase('ata-(ahead-of-time)', 'assertStrict', () => {
     }
 
     return true;
+  };
+});
+
+createCase('ata-(ahead-of-time)', 'parseSafe', () => {
+  return data => parseSanitized(data);
+});
+
+createCase('ata-(ahead-of-time)', 'parseStrict', () => {
+  return data => {
+    if (!isValidStrict(data)) {
+      throw new Error('invalid');
+    }
+
+    return data;
   };
 });

--- a/cases/ata-aot/src/generate.ts
+++ b/cases/ata-aot/src/generate.ts
@@ -42,16 +42,21 @@ strictSchema.properties.deeplyNested.additionalProperties = false;
 // Each call emits a self-contained module with its own helpers, so the two
 // schemas are written to separate files rather than concatenated.
 const targets = [
-  { schema: looseSchema, file: 'loose.js' },
-  { schema: strictSchema, file: 'strict.js' },
+  { schema: looseSchema, file: 'loose.js', parse: false },
+  { schema: strictSchema, file: 'strict.js', parse: false },
+  // parseSafe wants the validated document back with unknown keys gone. The
+  // emitted parse() rebuilds it from the properties the schema declares, so
+  // the copy costs the schema's size rather than the input's and the caller's
+  // object is left alone.
+  { schema: looseSchema, file: 'sanitize.js', parse: true },
 ];
 
 const outDir = join(process.cwd(), 'cases', 'ata-aot', 'src', 'generated');
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 
-for (const { schema, file } of targets) {
-  const source = toStandaloneModule(schema);
+for (const { schema, file, parse } of targets) {
+  const source = toStandaloneModule(schema, { parse });
   if (typeof source !== 'string') {
     throw new Error(`ata could not compile ${file} ahead of time`);
   }

--- a/cases/ata-aot/src/index.ts
+++ b/cases/ata-aot/src/index.ts
@@ -8,3 +8,8 @@ import { isValid as strictIsValid } from './generated/strict';
 
 export const isValidLoose = looseIsValid as (data: unknown) => boolean;
 export const isValidStrict = strictIsValid as (data: unknown) => boolean;
+
+// @ts-expect-error generated at build time
+import { parse as sanitizeParse } from './generated/sanitize';
+
+export const parseSanitized = sanitizeParse as (data: unknown) => unknown;

--- a/cases/ata.ts
+++ b/cases/ata.ts
@@ -62,3 +62,42 @@ createCase('ata', 'assertStrict', () => {
     return true;
   };
 });
+
+createCase('ata', 'parseSafe', () => {
+  // removeAdditional strips unknown keys in place, at every level the schema
+  // describes, which is what this benchmark asks for. The validator is built
+  // from the loose schema: unknown keys are removed rather than rejected.
+  const schema = JSON.parse(JSON.stringify(looseSchema));
+  schema.additionalProperties = false;
+  schema.properties.deeplyNested.additionalProperties = false;
+
+  const v = new Validator(schema, { removeAdditional: true });
+
+  return data => {
+    const result = v.validate(data);
+
+    if (!result.valid) {
+      throw new Error(JSON.stringify(result.errors));
+    }
+
+    return data;
+  };
+});
+
+createCase('ata', 'parseStrict', () => {
+  const schema = JSON.parse(JSON.stringify(looseSchema));
+  schema.additionalProperties = false;
+  schema.properties.deeplyNested.additionalProperties = false;
+
+  const v = new Validator(schema);
+
+  return data => {
+    const result = v.validate(data);
+
+    if (!result.valid) {
+      throw new Error(JSON.stringify(result.errors));
+    }
+
+    return data;
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/benchmark": "2.1.5",
         "ajv": "8.20.0",
         "arktype": "2.2.3",
-        "ata-validator": "1.10.0",
+        "ata-validator": "1.14.1",
         "banditypes": "0.3.0",
         "benny": "3.7.1",
         "bueno": "0.1.5",
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@ata-validator/native-darwin-arm64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.10.0.tgz",
-      "integrity": "sha512-ji72AWqJnnTGjT1GFGTCBJIndclKWko+r4gdwzyuSsm5AR61hDYVQDmYxzmI1yXxKRGabKqlMsqXwH34OhMZ7Q==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.14.1.tgz",
+      "integrity": "sha512-+ldRWZQXtGlwVNpMsUVnnZtEzC+hQVZu6dc8lZirdjCVQOkLu2rNHg4hoMkkFn3Vv7eMMRlNrfiS0MkpbILPbQ==",
       "cpu": [
         "arm64"
       ],
@@ -236,9 +236,9 @@
       ]
     },
     "node_modules/@ata-validator/native-darwin-x64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.10.0.tgz",
-      "integrity": "sha512-0pICN5GGpHhuTvhHJRR9IgigSl30zbzsIuDBTjKWZKoyQGcPZY1VSS29hZSVmYmVWdPoEZvDDGYRFdqjq/TSEw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.14.1.tgz",
+      "integrity": "sha512-2nrd/p1t6+BVeul1uUTUdZ8V5gtI80cLhdViMb8fbEQfc91wU3fYaM7Rr/WEyKLq5uUewIS8c/gp+2WIdh5t6Q==",
       "cpu": [
         "x64"
       ],
@@ -249,11 +249,14 @@
       ]
     },
     "node_modules/@ata-validator/native-linux-arm64-gnu": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.10.0.tgz",
-      "integrity": "sha512-n8oyif9KEUGLgWfCcaDiJNn8YnB4bNQsCpjr/fDA8bpD8HpgsfxkBAgtDKoAxQnQWZVuzgU++bcwRu04sDi2Vg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.14.1.tgz",
+      "integrity": "sha512-0WOChLughm9LqHldazSpZO9G4+1s5UmEz4ouYabWq9B0O/sVGI41Mp65HbqiCeF1FTNxRj8r0X20Hd3YhrZIPw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -262,11 +265,14 @@
       ]
     },
     "node_modules/@ata-validator/native-linux-arm64-musl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.10.0.tgz",
-      "integrity": "sha512-mkSQgkJGdotzf41mSVMnhZ+p5ecPcUBqHGBlx+vIidtvN4pXR1bhUKFaxT8JUU2hVyQy3onHeQfiI5hS/Gnewg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.14.1.tgz",
+      "integrity": "sha512-Kty0RbuxhOLg7uj+7MhHMIGazWdwIeqyscGhrJ1sKxtv2B0t6bYDNWUH6axLzLEXbe0L9I/y/hPCbC70DgLjkA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -275,11 +281,14 @@
       ]
     },
     "node_modules/@ata-validator/native-linux-x64-gnu": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.10.0.tgz",
-      "integrity": "sha512-TGWjqqwtB1LPwl08SOmK0Z7VDLYF9he1ETYREYBEEwFCEwGd8XuFz/jgRGbk5mQC1NJDaqtLNtu+RLTmgqaRzg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.14.1.tgz",
+      "integrity": "sha512-iE5CN6Fh3ejsB3CZQag70nnN4jegxBtD4w0MmG3J7c2rIUH6adw/Xkzhuk0AqAHIjFLeMw0JXOXb771fDp+Kag==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -288,11 +297,14 @@
       ]
     },
     "node_modules/@ata-validator/native-linux-x64-musl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.10.0.tgz",
-      "integrity": "sha512-05gTYrbKTIvKLgWjHLjZvlDCbSWoPZZhEmaFsgtsX4OdEASlCK+EmkVfwmD+oTvkvh6ASwvZ9bgpADwtgKCKvw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.14.1.tgz",
+      "integrity": "sha512-aqSRGe7MjmkEXXoIxWaBNL9c6O66vvMqz/oEQK4/FqE/FmnYfaI1ytM7pOeWhattjvzTLv4x+NbKxgEqgBPHlg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -301,9 +313,9 @@
       ]
     },
     "node_modules/@ata-validator/native-win32-x64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.10.0.tgz",
-      "integrity": "sha512-VQfGFGJBwrMRcpYk0u1y2KOQkaz3G8Hftw6eapUa7I7R6zdbZkWrNij93B+n9jVsQr48nVHzIlfI/PZq9pDoAw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.14.1.tgz",
+      "integrity": "sha512-3s315s9vDbw0wKE5dUirF0rhbGe64uXVPXTJ+vQUzUsLc7Uj9jg8ANE3oTojFSa4AB1Dxe/BoobksoP8O1UPFg==",
       "cpu": [
         "x64"
       ],
@@ -2925,7 +2937,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2938,7 +2949,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2951,7 +2961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2964,7 +2973,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2977,7 +2985,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2990,7 +2997,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3003,7 +3009,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3016,7 +3021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3029,7 +3033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3042,7 +3045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3055,7 +3057,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3068,7 +3069,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3081,7 +3081,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3094,7 +3093,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3107,7 +3105,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3120,7 +3117,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3133,7 +3129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3146,7 +3141,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3159,7 +3153,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -4083,9 +4076,9 @@
       }
     },
     "node_modules/ata-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.10.0.tgz",
-      "integrity": "sha512-BhL2sUy1P9OCwzc6BKFOX4RbExz2h8cUS37vyaa5n3M8n8nC1zk5G6+0h2bp5UiPQNiKs5q7+vGr3G6HVx5Tyg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.14.1.tgz",
+      "integrity": "sha512-75CiROZlk27mWcwg+Ov0+RB28JnGisiNoWGrBOS0WQlFrjAsqur3pHMeKvIycgciih8gryyx6H8XMHgRA5htzw==",
       "license": "MIT",
       "bin": {
         "ata": "bin/ata.js"
@@ -4094,13 +4087,13 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@ata-validator/native-darwin-arm64": "1.10.0",
-        "@ata-validator/native-darwin-x64": "1.10.0",
-        "@ata-validator/native-linux-arm64-gnu": "1.10.0",
-        "@ata-validator/native-linux-arm64-musl": "1.10.0",
-        "@ata-validator/native-linux-x64-gnu": "1.10.0",
-        "@ata-validator/native-linux-x64-musl": "1.10.0",
-        "@ata-validator/native-win32-x64": "1.10.0"
+        "@ata-validator/native-darwin-arm64": "1.14.1",
+        "@ata-validator/native-darwin-x64": "1.14.1",
+        "@ata-validator/native-linux-arm64-gnu": "1.14.1",
+        "@ata-validator/native-linux-arm64-musl": "1.14.1",
+        "@ata-validator/native-linux-x64-gnu": "1.14.1",
+        "@ata-validator/native-linux-x64-musl": "1.14.1",
+        "@ata-validator/native-win32-x64": "1.14.1"
       },
       "peerDependencies": {
         "yaml": "^2.0.0"
@@ -6216,7 +6209,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -11084,45 +11076,45 @@
       }
     },
     "@ata-validator/native-darwin-arm64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.10.0.tgz",
-      "integrity": "sha512-ji72AWqJnnTGjT1GFGTCBJIndclKWko+r4gdwzyuSsm5AR61hDYVQDmYxzmI1yXxKRGabKqlMsqXwH34OhMZ7Q==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-arm64/-/native-darwin-arm64-1.14.1.tgz",
+      "integrity": "sha512-+ldRWZQXtGlwVNpMsUVnnZtEzC+hQVZu6dc8lZirdjCVQOkLu2rNHg4hoMkkFn3Vv7eMMRlNrfiS0MkpbILPbQ==",
       "optional": true
     },
     "@ata-validator/native-darwin-x64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.10.0.tgz",
-      "integrity": "sha512-0pICN5GGpHhuTvhHJRR9IgigSl30zbzsIuDBTjKWZKoyQGcPZY1VSS29hZSVmYmVWdPoEZvDDGYRFdqjq/TSEw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-darwin-x64/-/native-darwin-x64-1.14.1.tgz",
+      "integrity": "sha512-2nrd/p1t6+BVeul1uUTUdZ8V5gtI80cLhdViMb8fbEQfc91wU3fYaM7Rr/WEyKLq5uUewIS8c/gp+2WIdh5t6Q==",
       "optional": true
     },
     "@ata-validator/native-linux-arm64-gnu": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.10.0.tgz",
-      "integrity": "sha512-n8oyif9KEUGLgWfCcaDiJNn8YnB4bNQsCpjr/fDA8bpD8HpgsfxkBAgtDKoAxQnQWZVuzgU++bcwRu04sDi2Vg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-gnu/-/native-linux-arm64-gnu-1.14.1.tgz",
+      "integrity": "sha512-0WOChLughm9LqHldazSpZO9G4+1s5UmEz4ouYabWq9B0O/sVGI41Mp65HbqiCeF1FTNxRj8r0X20Hd3YhrZIPw==",
       "optional": true
     },
     "@ata-validator/native-linux-arm64-musl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.10.0.tgz",
-      "integrity": "sha512-mkSQgkJGdotzf41mSVMnhZ+p5ecPcUBqHGBlx+vIidtvN4pXR1bhUKFaxT8JUU2hVyQy3onHeQfiI5hS/Gnewg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-arm64-musl/-/native-linux-arm64-musl-1.14.1.tgz",
+      "integrity": "sha512-Kty0RbuxhOLg7uj+7MhHMIGazWdwIeqyscGhrJ1sKxtv2B0t6bYDNWUH6axLzLEXbe0L9I/y/hPCbC70DgLjkA==",
       "optional": true
     },
     "@ata-validator/native-linux-x64-gnu": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.10.0.tgz",
-      "integrity": "sha512-TGWjqqwtB1LPwl08SOmK0Z7VDLYF9he1ETYREYBEEwFCEwGd8XuFz/jgRGbk5mQC1NJDaqtLNtu+RLTmgqaRzg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-gnu/-/native-linux-x64-gnu-1.14.1.tgz",
+      "integrity": "sha512-iE5CN6Fh3ejsB3CZQag70nnN4jegxBtD4w0MmG3J7c2rIUH6adw/Xkzhuk0AqAHIjFLeMw0JXOXb771fDp+Kag==",
       "optional": true
     },
     "@ata-validator/native-linux-x64-musl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.10.0.tgz",
-      "integrity": "sha512-05gTYrbKTIvKLgWjHLjZvlDCbSWoPZZhEmaFsgtsX4OdEASlCK+EmkVfwmD+oTvkvh6ASwvZ9bgpADwtgKCKvw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-linux-x64-musl/-/native-linux-x64-musl-1.14.1.tgz",
+      "integrity": "sha512-aqSRGe7MjmkEXXoIxWaBNL9c6O66vvMqz/oEQK4/FqE/FmnYfaI1ytM7pOeWhattjvzTLv4x+NbKxgEqgBPHlg==",
       "optional": true
     },
     "@ata-validator/native-win32-x64": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.10.0.tgz",
-      "integrity": "sha512-VQfGFGJBwrMRcpYk0u1y2KOQkaz3G8Hftw6eapUa7I7R6zdbZkWrNij93B+n9jVsQr48nVHzIlfI/PZq9pDoAw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@ata-validator/native-win32-x64/-/native-win32-x64-1.14.1.tgz",
+      "integrity": "sha512-3s315s9vDbw0wKE5dUirF0rhbGe64uXVPXTJ+vQUzUsLc7Uj9jg8ANE3oTojFSa4AB1Dxe/BoobksoP8O1UPFg==",
       "optional": true
     },
     "@babel/cli": {
@@ -12846,133 +12838,114 @@
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
       "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-android-arm64": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
       "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-arm64": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
       "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-x64": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
       "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-freebsd-arm64": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
       "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-freebsd-x64": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
       "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
       "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
       "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
       "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
       "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
       "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
       "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
       "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-s390x-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
       "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
       "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
       "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-arm64-msvc": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
       "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-ia32-msvc": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
       "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-x64-msvc": {
       "version": "4.30.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
       "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
-      "dev": true,
       "optional": true
     },
     "@samchon/openapi": {
@@ -13623,17 +13596,17 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "ata-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.10.0.tgz",
-      "integrity": "sha512-BhL2sUy1P9OCwzc6BKFOX4RbExz2h8cUS37vyaa5n3M8n8nC1zk5G6+0h2bp5UiPQNiKs5q7+vGr3G6HVx5Tyg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/ata-validator/-/ata-validator-1.14.1.tgz",
+      "integrity": "sha512-75CiROZlk27mWcwg+Ov0+RB28JnGisiNoWGrBOS0WQlFrjAsqur3pHMeKvIycgciih8gryyx6H8XMHgRA5htzw==",
       "requires": {
-        "@ata-validator/native-darwin-arm64": "1.10.0",
-        "@ata-validator/native-darwin-x64": "1.10.0",
-        "@ata-validator/native-linux-arm64-gnu": "1.10.0",
-        "@ata-validator/native-linux-arm64-musl": "1.10.0",
-        "@ata-validator/native-linux-x64-gnu": "1.10.0",
-        "@ata-validator/native-linux-x64-musl": "1.10.0",
-        "@ata-validator/native-win32-x64": "1.10.0"
+        "@ata-validator/native-darwin-arm64": "1.14.1",
+        "@ata-validator/native-darwin-x64": "1.14.1",
+        "@ata-validator/native-linux-arm64-gnu": "1.14.1",
+        "@ata-validator/native-linux-arm64-musl": "1.14.1",
+        "@ata-validator/native-linux-x64-gnu": "1.14.1",
+        "@ata-validator/native-linux-x64-musl": "1.14.1",
+        "@ata-validator/native-win32-x64": "1.14.1"
       }
     },
     "atob": {
@@ -15086,7 +15059,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/benchmark": "2.1.5",
     "ajv": "8.20.0",
     "arktype": "2.2.3",
-    "ata-validator": "1.10.0",
+    "ata-validator": "1.14.1",
     "banditypes": "0.3.0",
     "benny": "3.7.1",
     "bueno": "0.1.5",


### PR DESCRIPTION
Fills in the two benchmarks both `ata` entries were missing. My earlier PR left them out with the note that the library validates rather than parses; that is no longer true, so here they are.

`parseSafe` needs the validated document back with unknown keys gone. The runtime entry uses `removeAdditional`, which strips them in place at every level the schema describes. The ahead-of-time entry uses `parse()`, new in ata 1.14.0: the emitted module rebuilds the document from the properties the schema declares, so the copy costs the schema's size rather than the input's and the caller's object is left alone. That is the difference between the two `parseSafe` rows below.

`parseStrict` is the strict schema plus returning the input, same shape as the existing `assertStrict` entries.

Local numbers on this harness, Node 24, `ts-node index.ts run ata ata-aot`:

| Case | ata (runtime) | ata (ahead-of-time) |
| --- | --- | --- |
| parseSafe | 33.5M ops/s | 82.1M ops/s |
| parseStrict | 69.3M ops/s | 82.2M ops/s |
| assertLoose | 128.3M ops/s | 158.3M ops/s |
| assertStrict | 69.9M ops/s | 82.5M ops/s |

Verification:

- all five contract tests pass for each of the four new cases, including the nested extra-key ones for both directions
- `npm run compile:ata-aot` emits the extra module the `parseSafe` entry loads; generated output stays gitignored
- `tsc --noEmit` reports nothing for these files
- `ata-validator` moves from 1.10.0 to 1.14.1, which is where `parse()` and the nested `removeAdditional` fix live

Two things I found while writing this and fixed upstream rather than working around here: `removeAdditional` only stripped the root object, and it disagreed with the interpreted path on nested objects. Both are in 1.14.0.
